### PR TITLE
Build fixes for newer gcc versions

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -20,7 +20,7 @@ endif
 all:	${BUILD_DIR} $(BUILD_DIR)/dedisperse-gpu ${ASTROLIB_DIR} ${ASTROLIB_DIR}/libastrolib.a
 
 $(BUILD_DIR)/%.o : %.cu
-	nvcc -o $@ -c $(NVCCFLAGS) $< 
+	nvcc -o $@ -c $(NVCCFLAGS) $<
 
 $(BUILD_DIR)/%.o : %.cpp
 	nvcc -o $@ -c $(NVCCFLAGS) $<
@@ -30,19 +30,19 @@ ${ASTROLIB_DIR}:
 
 ${BUILD_DIR}:
 	mkdir -p ${BUILD_DIR}
-	
+
 
 $(BUILD_DIR)/main.o : 					AstroAccelerate/headers_mains.h
 
-$(BUILD_DIR)/host_main_function.o:		AstroAccelerate/host_main_function.h 
+$(BUILD_DIR)/host_main_function.o:		AstroAccelerate/host_main_function.h
 
 $(BUILD_DIR)/host_allocate_memory.o:	AstroAccelerate/host_allocate_memory.h
 
 $(BUILD_DIR)/host_acceleration.o:		AstroAccelerate/host_acceleration.h
 
-$(BUILD_DIR)/host_analysis.o:			AstroAccelerate/host_analysis.h 
+$(BUILD_DIR)/host_analysis.o:			AstroAccelerate/host_analysis.h
 
-$(BUILD_DIR)/host_periods.o:			AstroAccelerate/host_periods.h 
+$(BUILD_DIR)/host_periods.o:			AstroAccelerate/host_periods.h
 
 $(BUILD_DIR)/host_debug.o:	 			AstroAccelerate/host_debug.h
 
@@ -74,8 +74,8 @@ $(ASTROLIB_DIR)/libastrolib.a: $(BUILD_DIR)/host_acceleration.o $(BUILD_DIR)/hos
 	$(BUILD_DIR)/host_get_recorded_data.o $(BUILD_DIR)/host_help.o $(BUILD_DIR)/host_rfi.o $(BUILD_DIR)/host_stratagy.o $(BUILD_DIR)/host_statistics.o \
 	$(BUILD_DIR)/host_main_function.o
 
-$(BUILD_DIR)/dedisperse-gpu: $(BUILD_DIR)/main.o $(ASTROLIB_DIR)/libastrolib.a 
-	nvcc -o $(BUILD_DIR)/dedisperse-gpu $(BUILD_DIR)/main.o $(NVCCFLAGS) -L$(ASTROLIB_DIR)/ -lastrolib
+$(BUILD_DIR)/dedisperse-gpu: $(BUILD_DIR)/main.o $(ASTROLIB_DIR)/libastrolib.a
+	nvcc -o $(BUILD_DIR)/dedisperse-gpu $(BUILD_DIR)/main.o -L$(ASTROLIB_DIR)/ -lastrolib -L${LIB} $(NVCCFLAGS)
 
 clean:
 	rm -f $(BUILD_DIR)/dedisperse-gpu $(BUILD_DIR)/*.a $(BUILD_DIR)/*.o $(ASTROLIB_DIR)/*.a

--- a/lib/Makefile_52
+++ b/lib/Makefile_52
@@ -18,20 +18,20 @@ endif
 all:	${BUILD_DIR} $(BUILD_DIR)/dedisperse-gpu
 
 $(BUILD_DIR)/%.o : %.cu
-	nvcc -o $@ -c $(NVCCFLAGS) $< 
+	nvcc -o $@ -c $(NVCCFLAGS) $<
 
 ${BUILD_DIR}:
 	mkdir -p ${BUILD_DIR}
 
-$(BUILD_DIR)/host_main.o:	AstroAccelerate/headers_mains.h 
+$(BUILD_DIR)/host_main.o:	AstroAccelerate/headers_mains.h
 
 $(BUILD_DIR)/host_allocate_memory.o:	AstroAccelerate/host_allocate_memory.h
 
 $(BUILD_DIR)/host_acceleration.o:	AstroAccelerate/host_acceleration.h
 
-$(BUILD_DIR)/host_analysis.o:	 AstroAccelerate/host_analysis.h 
+$(BUILD_DIR)/host_analysis.o:	 AstroAccelerate/host_analysis.h
 
-$(BUILD_DIR)/host_periods.o:	 AstroAccelerate/host_periods.h 
+$(BUILD_DIR)/host_periods.o:	 AstroAccelerate/host_periods.h
 
 $(BUILD_DIR)/host_debug.o:	 AstroAccelerate/host_debug.h
 
@@ -55,7 +55,7 @@ $(BUILD_DIR)/host_write_file.o:	 AstroAccelerate/host_write_file.h
 #	nvcc -c $(NVCCFLAGS) device_main.cu
 
 $(BUILD_DIR)/dedisperse-gpu:	$(BUILD_DIR)/host_main.o $(BUILD_DIR)/host_allocate_memory.o $(BUILD_DIR)/host_acceleration.o $(BUILD_DIR)/host_analysis.o $(BUILD_DIR)/host_periods.o $(BUILD_DIR)/host_debug.o $(BUILD_DIR)/host_get_file_data.o $(BUILD_DIR)/host_get_user_input.o $(BUILD_DIR)/host_get_recorded_data.o $(BUILD_DIR)/host_help.o $(BUILD_DIR)/host_rfi.o $(BUILD_DIR)/host_stratagy.o $(BUILD_DIR)/host_statistics.o $(BUILD_DIR)/host_write_file.o $(BUILD_DIR)/device_main.o
-	nvcc -o $(BUILD_DIR)/dedisperse-gpu $(NVCCFLAGS) $(BUILD_DIR)/host_main.o $(BUILD_DIR)/host_allocate_memory.o $(BUILD_DIR)/host_acceleration.o $(BUILD_DIR)/host_analysis.o $(BUILD_DIR)/host_periods.o $(BUILD_DIR)/host_debug.o $(BUILD_DIR)/host_get_file_data.o $(BUILD_DIR)/host_get_user_input.o $(BUILD_DIR)/host_get_recorded_data.o $(BUILD_DIR)/host_help.o $(BUILD_DIR)/host_rfi.o $(BUILD_DIR)/host_stratagy.o $(BUILD_DIR)/host_statistics.o $(BUILD_DIR)/host_write_file.o $(BUILD_DIR)/device_main.o
+	nvcc -o $(BUILD_DIR)/dedisperse-gpu -L${LIB} $(NVCCFLAGS) $(BUILD_DIR)/host_main.o $(BUILD_DIR)/host_allocate_memory.o $(BUILD_DIR)/host_acceleration.o $(BUILD_DIR)/host_analysis.o $(BUILD_DIR)/host_periods.o $(BUILD_DIR)/host_debug.o $(BUILD_DIR)/host_get_file_data.o $(BUILD_DIR)/host_get_user_input.o $(BUILD_DIR)/host_get_recorded_data.o $(BUILD_DIR)/host_help.o $(BUILD_DIR)/host_rfi.o $(BUILD_DIR)/host_stratagy.o $(BUILD_DIR)/host_statistics.o $(BUILD_DIR)/host_write_file.o $(BUILD_DIR)/device_main.o
 
 clean:
 	rm -f $(BUILD_DIR)/dedisperse-gpu $(BUILD_DIR)/*.a $(BUILD_DIR)/*.o


### PR DESCRIPTION
Newer versions of GCC require the libraries to be defined in order
of their dependencies with later libraries depending upon the
earlier.

Astro lib depends upon the cuda libraries so these need to be on the
commandline later in the link process.