### PR TITLE
Limit the GPU memory utilisation up to 8 GB

### DIFF
--- a/src/aa_ddtr_strategy.cpp
+++ b/src/aa_ddtr_strategy.cpp
@@ -14,7 +14,7 @@ namespace astroaccelerate {
    * Constructor for aa_ddtr_strategy that computes the strategy upon construction, and sets the ready state of the instance of the class.
    */
   aa_ddtr_strategy::aa_ddtr_strategy(const aa_ddtr_plan &plan, const aa_filterbank_metadata &metadata, const size_t &free_memory, const bool &enable_analysis) : m_ready(false), m_strategy_already_calculated(false), m_configured_for_analysis(enable_analysis), is_setup(false), m_metadata(metadata), m_maxshift(0), m_num_tchunks(0), m_total_ndms(0), m_max_dm(0.0), m_maxshift_high(0), m_max_ndms(0), m_power(plan.power()), m_enable_msd_baseline_noise(plan.enable_msd_baseline_noise()) {    
-    strategy(plan, free_memory, enable_analysis);
+    strategy(plan, ((free_memory < 8000000000) ? free_memory : 8000000000), enable_analysis);
   }
 
   /**


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve

---

**Description of pull request**
Limit the GPU memory utilisation to the lesser of the free memory up to 8 GB. This will enable the current kernels to run on GPUs with more than 8 GB of memory and is an interim solution towards upgrading the kernels to support GPUs with more than 8 GB of memory.

**Interfaces**
Will this pull request result in a backwards-incompatible interface change: No.

Expected semantic version number increment category (Please indicate x.y.z): z.


**Issues this pull request solves**
Fixes #143.

**New tag of master**
Yes.

**New deployment**
See above.

**Keep branch after merging**
No.

**Notes**
N/A.