### PR TITLE
Remove keyword for policy warning on older CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ include_directories(${CUDA_LIBRARY_DIRS})
 # CUDA library object
 file(GLOB_RECURSE GPU_SOURCE_FILES "src/*.cu" "src/*.cpp")
 cuda_add_library(astroaccelerate SHARED ${GPU_SOURCE_FILES})
-target_link_libraries(astroaccelerate PRIVATE ${CUDA_LIBRARIES} ${CUDA_CUFFT_LIBRARIES} ${CUDA_curand_LIBRARY})
+target_link_libraries(astroaccelerate ${CUDA_LIBRARIES} ${CUDA_CUFFT_LIBRARIES} ${CUDA_curand_LIBRARY})
 set_target_properties(astroaccelerate PROPERTIES CUDA_SEPARABLE_COMPILATION OFF)
 set_target_properties(astroaccelerate PROPERTIES POSITION_INDEPENDENT_CODE ON)
 set_target_properties(astroaccelerate PROPERTIES BUILD_SHARED_LIBS ON)


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve

---

**Description of pull request**
Remove keyword PRIVATE for older CMake warning.

**Interfaces**
Will this pull request result in a backwards-incompatible interface change: No.

Expected semantic version number increment category (Please indicate x.y.z): z.


**Issues this pull request solves**
No issues tagged.

**New tag of master**
Yes.

**New deployment**
See above.

**Keep branch after merging**
No.

**Notes**
N/A.