### PR TITLE
Fix for #define for compilation using makefile only

### DIFF
--- a/include/aa_device_info.hpp
+++ b/include/aa_device_info.hpp
@@ -146,7 +146,8 @@ namespace astroaccelerate {
           return false;
         }
       }
-      
+
+#ifdef ASTRO_ACCELERATE_VERSION_H_DEFINED
       std::vector<int> compiled_cuda_sm_versions;
       std::stringstream s(ASTRO_ACCELERATE_CUDA_SM_VERSION);
       int i;
@@ -157,6 +158,7 @@ namespace astroaccelerate {
 	  s.ignore();
 	}
       }
+#endif
       
       for(size_t i = 0; i < m_card_info.size(); i++) {
 	if(m_card_info.at(i).card_number == id) {


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to help us improve

---

**Description of pull request**
Add a `#define` around code in `aa_device_info.hpp` so that compilation with the `Makefile` works without running CMake first.


**Interfaces**
Will this pull request result in a backwards-incompatible interface change: No.

Expected semantic version number increment category (Please indicate x.y.z): z.


**Issues this pull request solves**
No issues tagged.

**New tag of master**
Yes.

**New deployment**
See above.

**Keep branch after merging**
No.

**Notes**
N/A.