### PR TITLE
Ka 201 dedisperze

### DIFF
--- a/include/aa_dedisperse.hpp
+++ b/include/aa_dedisperse.hpp
@@ -17,7 +17,7 @@ namespace astroaccelerate {
    * \brief Function that performs the dedispersion on the GPU.
    * \brief Users should not need to interact with this function directly.
    */
-  void dedisperse(int i, int t_processed, int *inBin, float *dmshifts, unsigned short *d_input, float *d_output, int nchans, float *tsamp, float *dm_low, float *dm_step, int const*const ndms, int nbits, int failsafe);
+  void dedisperse(int i, int t_processed, int *inBin, float *dmshifts, unsigned short *d_input, float *d_output, float *d_dm_shifts, int nchans, float *tsamp, float *dm_low, float *dm_step, int const*const ndms, int nbits, int failsafe);
 
 } // namespace astroaccelerate
   

--- a/include/aa_device_dedispersion_kernel.hpp
+++ b/include/aa_device_dedispersion_kernel.hpp
@@ -17,9 +17,15 @@ namespace astroaccelerate {
 
   /** \brief Kernel wrapper function for shared_dedisperse_kernel kernel function. */
   void call_kernel_shared_dedisperse_kernel(const dim3 &block_size, const dim3 &grid_size, const int &bin, unsigned short *const d_input, float *const d_output, const float &mstartdm, const float &mdmstep);
+  
+	/** \brief Kernel wrapper function for dedispersion GPU kernel which works with number of channels greater then 8192. */
+	void call_kernel_shared_dedisperse_kernel_nchan8192p(const dim3 &block_size, const dim3 &grid_size, const int &bin, unsigned short *const d_input, float *const d_output, float *const d_dm_shifts, const float &mstartdm, const float &mdmstep);
 
   /** \brief Kernel wrapper function for shared_dedisperse_kernel_16 kernel function. */
   void call_kernel_shared_dedisperse_kernel_16(const dim3 &block_size, const dim3 &grid_size, const int &bin, unsigned short *const d_input, float *const d_output, const float &mstartdm, const float &mdmstep);
+  
+	/** \brief Kernel wrapper function for dedispersion kernel which works with 16bit data and when number of channels is greater than 8192 kernel function. */
+	void call_kernel_shared_dedisperse_kernel_16_nchan8192p(const dim3 &block_size, const dim3 &grid_size, const int &bin, unsigned short *const d_input, float *const d_output, float *const d_dm_shifts, const float &mstartdm, const float &mdmstep);
 
   /** \brief Kernel wrapper function for cache_dedisperse_kernel kernel function. */
   void call_kernel_cache_dedisperse_kernel(const dim3 &block_size, const dim3 &grid_size, const int &bin, unsigned short *const d_input, float *const d_output, const float &mstartdm, const float &mdmstep);

--- a/include/aa_device_dedispersion_kernel.hpp
+++ b/include/aa_device_dedispersion_kernel.hpp
@@ -29,6 +29,8 @@ namespace astroaccelerate {
 
   /** \brief Kernel wrapper function for cache_dedisperse_kernel kernel function. */
   void call_kernel_cache_dedisperse_kernel(const dim3 &block_size, const dim3 &grid_size, const int &bin, unsigned short *const d_input, float *const d_output, const float &mstartdm, const float &mdmstep);
+  
+	void call_kernel_cache_dedisperse_kernel_nchan8192p(const dim3 &block_size, const dim3 &grid_size, const int &bin, unsigned short *const d_input, float *const d_output, float *const d_dm_shifts, const float &mstartdm, const float &mdmstep);
 
 } // namespace astroaccelerate
 #endif // ASTRO_ACCELERATE_AA_DEDISPERSION_KERNEL_HPP

--- a/include/aa_device_load_data.hpp
+++ b/include/aa_device_load_data.hpp
@@ -10,7 +10,7 @@ namespace astroaccelerate {
    * Loads data from the host memory into the GPU memory.
    * Users should not need to interact with this function directly.
    */
-  void load_data(int i, int *inBin, unsigned short *device_pointer, unsigned short const*const host_pointer, int t_processed, int maxshift, int nchans, float *dmshifts);
+  void load_data(int i, int *inBin, unsigned short *device_pointer, unsigned short const*const host_pointer, int t_processed, int maxshift, int nchans, float *dmshifts, float *d_dm_shifts);
 
 } // namespace astroaccelerate
 

--- a/include/aa_permitted_pipelines_1.hpp
+++ b/include/aa_permitted_pipelines_1.hpp
@@ -335,7 +335,7 @@ namespace astroaccelerate {
       const int *ndms = m_ddtr_strategy.ndms_data();
 
       //checkCudaErrors(cudaGetLastError());
-      load_data(-1, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[0][t], maxshift, nchans, dmshifts);
+      load_data(-1, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[0][t], maxshift, nchans, dmshifts, NULL);
       //checkCudaErrors(cudaGetLastError());
       
       if(zero_dm_type == aa_pipeline::component_option::zero_dm) {
@@ -372,7 +372,7 @@ namespace astroaccelerate {
 	cudaDeviceSynchronize();
 	//checkCudaErrors(cudaGetLastError());
 
-	load_data(dm_range, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[dm_range][t], maxshift, nchans, dmshifts);
+	load_data(dm_range, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[dm_range][t], maxshift, nchans, dmshifts, NULL);
 
 	//checkCudaErrors(cudaGetLastError());
 
@@ -384,7 +384,7 @@ namespace astroaccelerate {
 
 	//checkCudaErrors(cudaGetLastError());
 
-	dedisperse(dm_range, t_processed[dm_range][t], inBin.data(), dmshifts, d_input, d_output, nchans, &tsamp, dm_low.data(), dm_step.data(), ndms, nbits, failsafe);
+	dedisperse(dm_range, t_processed[dm_range][t], inBin.data(), dmshifts, d_input, d_output, NULL, nchans, &tsamp, dm_low.data(), dm_step.data(), ndms, nbits, failsafe);
 
 	if(dump_to_host) {
 	  for (int k = 0; k < ndms[dm_range]; k++) {

--- a/include/aa_permitted_pipelines_2.hpp
+++ b/include/aa_permitted_pipelines_2.hpp
@@ -371,7 +371,7 @@ namespace astroaccelerate {
       const int *ndms = m_ddtr_strategy.ndms_data();
 
       //checkCudaErrors(cudaGetLastError());
-      load_data(-1, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[0][t], maxshift, nchans, dmshifts);
+      load_data(-1, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[0][t], maxshift, nchans, dmshifts, NULL);
       //checkCudaErrors(cudaGetLastError());
 
       if(zero_dm_type == aa_pipeline::component_option::zero_dm) {
@@ -414,7 +414,7 @@ namespace astroaccelerate {
 	cudaDeviceSynchronize();
 	//checkCudaErrors(cudaGetLastError());
 
-	load_data(dm_range, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[dm_range][t], maxshift, nchans, dmshifts);
+	load_data(dm_range, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[dm_range][t], maxshift, nchans, dmshifts, NULL);
 
 	//checkCudaErrors(cudaGetLastError());
 
@@ -426,7 +426,7 @@ namespace astroaccelerate {
 
 	//checkCudaErrors(cudaGetLastError());
 
-	dedisperse(dm_range, t_processed[dm_range][t], inBin.data(), dmshifts, d_input, d_output, nchans, &tsamp, dm_low.data(), dm_step.data(), ndms, nbits, failsafe);
+	dedisperse(dm_range, t_processed[dm_range][t], inBin.data(), dmshifts, d_input, d_output, NULL, nchans, &tsamp, dm_low.data(), dm_step.data(), ndms, nbits, failsafe);
 
 	//checkCudaErrors(cudaGetLastError());
 

--- a/include/aa_permitted_pipelines_3.hpp
+++ b/include/aa_permitted_pipelines_3.hpp
@@ -370,7 +370,7 @@ namespace astroaccelerate {
       const int *ndms = m_ddtr_strategy.ndms_data();
       
       //checkCudaErrors(cudaGetLastError());
-      load_data(-1, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[0][t], maxshift, nchans, dmshifts);
+      load_data(-1, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[0][t], maxshift, nchans, dmshifts, NULL);
       //checkCudaErrors(cudaGetLastError());
 
       if(zero_dm_type == aa_pipeline::component_option::zero_dm) {
@@ -406,7 +406,7 @@ namespace astroaccelerate {
 	cudaDeviceSynchronize();
 	//checkCudaErrors(cudaGetLastError());
 
-	load_data(dm_range, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[dm_range][t], maxshift, nchans, dmshifts);
+	load_data(dm_range, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[dm_range][t], maxshift, nchans, dmshifts, NULL);
 
 	//checkCudaErrors(cudaGetLastError());
 
@@ -418,7 +418,7 @@ namespace astroaccelerate {
 
 	//checkCudaErrors(cudaGetLastError());
 
-	dedisperse(dm_range, t_processed[dm_range][t], inBin.data(), dmshifts, d_input, d_output, nchans, &tsamp, dm_low.data(), dm_step.data(), ndms, nbits, failsafe);
+	dedisperse(dm_range, t_processed[dm_range][t], inBin.data(), dmshifts, d_input, d_output, NULL, nchans, &tsamp, dm_low.data(), dm_step.data(), ndms, nbits, failsafe);
 
 	//checkCudaErrors(cudaGetLastError());
 

--- a/include/aa_permitted_pipelines_3_0.hpp
+++ b/include/aa_permitted_pipelines_3_0.hpp
@@ -309,7 +309,7 @@ namespace astroaccelerate {
       const int *ndms = m_ddtr_strategy.ndms_data();
       
       //checkCudaErrors(cudaGetLastError());
-      load_data(-1, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[0][t], maxshift, nchans, dmshifts);
+      load_data(-1, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[0][t], maxshift, nchans, dmshifts, NULL);
       //checkCudaErrors(cudaGetLastError());
 
       if(zero_dm_type == aa_pipeline::component_option::zero_dm) {
@@ -345,7 +345,7 @@ namespace astroaccelerate {
 	cudaDeviceSynchronize();
 	//checkCudaErrors(cudaGetLastError());
 
-	load_data(dm_range, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[dm_range][t], maxshift, nchans, dmshifts);
+	load_data(dm_range, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[dm_range][t], maxshift, nchans, dmshifts, NULL);
 
 	//checkCudaErrors(cudaGetLastError());
 
@@ -357,7 +357,7 @@ namespace astroaccelerate {
 
 	//checkCudaErrors(cudaGetLastError());
 
-	dedisperse(dm_range, t_processed[dm_range][t], inBin.data(), dmshifts, d_input, d_output, nchans, &tsamp, dm_low.data(), dm_step.data(), ndms, nbits, failsafe);
+	dedisperse(dm_range, t_processed[dm_range][t], inBin.data(), dmshifts, d_input, d_output, NULL, nchans, &tsamp, dm_low.data(), dm_step.data(), ndms, nbits, failsafe);
 
 	//checkCudaErrors(cudaGetLastError());
 

--- a/include/aa_permitted_pipelines_4.hpp
+++ b/include/aa_permitted_pipelines_4.hpp
@@ -361,7 +361,7 @@ namespace astroaccelerate {
       const int *ndms = m_ddtr_strategy.ndms_data();
       
       //checkCudaErrors(cudaGetLastError());
-      load_data(-1, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[0][t], maxshift, nchans, dmshifts);
+      load_data(-1, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[0][t], maxshift, nchans, dmshifts, NULL);
       //checkCudaErrors(cudaGetLastError());
 
       if(zero_dm_type == aa_pipeline::component_option::zero_dm) {
@@ -397,7 +397,7 @@ namespace astroaccelerate {
 	cudaDeviceSynchronize();
 	//checkCudaErrors(cudaGetLastError());
 
-	load_data(dm_range, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[dm_range][t], maxshift, nchans, dmshifts);
+	load_data(dm_range, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[dm_range][t], maxshift, nchans, dmshifts, NULL);
 
 	//checkCudaErrors(cudaGetLastError());
 
@@ -409,7 +409,7 @@ namespace astroaccelerate {
 
 	//checkCudaErrors(cudaGetLastError());
 
-	dedisperse(dm_range, t_processed[dm_range][t], inBin.data(), dmshifts, d_input, d_output, nchans, &tsamp, dm_low.data(), dm_step.data(), ndms, nbits, failsafe);
+	dedisperse(dm_range, t_processed[dm_range][t], inBin.data(), dmshifts, d_input, d_output, NULL, nchans, &tsamp, dm_low.data(), dm_step.data(), ndms, nbits, failsafe);
 
 	//checkCudaErrors(cudaGetLastError());
 

--- a/include/aa_permitted_pipelines_4_0.hpp
+++ b/include/aa_permitted_pipelines_4_0.hpp
@@ -347,7 +347,7 @@ namespace astroaccelerate {
       const int *ndms = m_ddtr_strategy.ndms_data();
       
       //checkCudaErrors(cudaGetLastError());
-      load_data(-1, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[0][t], maxshift, nchans, dmshifts);
+      load_data(-1, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[0][t], maxshift, nchans, dmshifts, NULL);
       //checkCudaErrors(cudaGetLastError());
 
       if(zero_dm_type == aa_pipeline::component_option::zero_dm) {
@@ -383,7 +383,7 @@ namespace astroaccelerate {
 	cudaDeviceSynchronize();
 	//checkCudaErrors(cudaGetLastError());
 
-	load_data(dm_range, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[dm_range][t], maxshift, nchans, dmshifts);
+	load_data(dm_range, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[dm_range][t], maxshift, nchans, dmshifts, NULL);
 
 	//checkCudaErrors(cudaGetLastError());
 
@@ -395,7 +395,7 @@ namespace astroaccelerate {
 
 	//checkCudaErrors(cudaGetLastError());
 
-	dedisperse(dm_range, t_processed[dm_range][t], inBin.data(), dmshifts, d_input, d_output, nchans, &tsamp, dm_low.data(), dm_step.data(), ndms, nbits, failsafe);
+	dedisperse(dm_range, t_processed[dm_range][t], inBin.data(), dmshifts, d_input, d_output, NULL, nchans, &tsamp, dm_low.data(), dm_step.data(), ndms, nbits, failsafe);
 
 	//checkCudaErrors(cudaGetLastError());
 

--- a/include/aa_permitted_pipelines_5.hpp
+++ b/include/aa_permitted_pipelines_5.hpp
@@ -378,7 +378,7 @@ namespace astroaccelerate {
       const int *ndms = m_ddtr_strategy.ndms_data();
       
       //checkCudaErrors(cudaGetLastError());
-      load_data(-1, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[0][t], maxshift, nchans, dmshifts);
+      load_data(-1, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[0][t], maxshift, nchans, dmshifts, NULL);
       //checkCudaErrors(cudaGetLastError());
 
       if(zero_dm_type == aa_pipeline::component_option::zero_dm) {
@@ -414,7 +414,7 @@ namespace astroaccelerate {
 	cudaDeviceSynchronize();
 	//checkCudaErrors(cudaGetLastError());
 
-	load_data(dm_range, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[dm_range][t], maxshift, nchans, dmshifts);
+	load_data(dm_range, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[dm_range][t], maxshift, nchans, dmshifts, NULL);
 
 	//checkCudaErrors(cudaGetLastError());
 
@@ -426,7 +426,7 @@ namespace astroaccelerate {
 
 	//checkCudaErrors(cudaGetLastError());
 
-	dedisperse(dm_range, t_processed[dm_range][t], inBin.data(), dmshifts, d_input, d_output, nchans, &tsamp, dm_low.data(), dm_step.data(), ndms, nbits, failsafe);
+	dedisperse(dm_range, t_processed[dm_range][t], inBin.data(), dmshifts, d_input, d_output, NULL, nchans, &tsamp, dm_low.data(), dm_step.data(), ndms, nbits, failsafe);
 
 	//checkCudaErrors(cudaGetLastError());
 

--- a/include/aa_permitted_pipelines_5_0.hpp
+++ b/include/aa_permitted_pipelines_5_0.hpp
@@ -340,7 +340,7 @@ namespace astroaccelerate {
       const int *ndms = m_ddtr_strategy.ndms_data();
       
       //checkCudaErrors(cudaGetLastError());
-      load_data(-1, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[0][t], maxshift, nchans, dmshifts);
+      load_data(-1, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[0][t], maxshift, nchans, dmshifts, NULL);
       //checkCudaErrors(cudaGetLastError());
 
       if(zero_dm_type == aa_pipeline::component_option::zero_dm) {
@@ -376,7 +376,7 @@ namespace astroaccelerate {
 	cudaDeviceSynchronize();
 	//checkCudaErrors(cudaGetLastError());
 
-	load_data(dm_range, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[dm_range][t], maxshift, nchans, dmshifts);
+	load_data(dm_range, inBin.data(), d_input, &m_input_buffer[(long int) ( inc * nchans )], t_processed[dm_range][t], maxshift, nchans, dmshifts, NULL);
 
 	//checkCudaErrors(cudaGetLastError());
 
@@ -388,7 +388,7 @@ namespace astroaccelerate {
 
 	//checkCudaErrors(cudaGetLastError());
 
-	dedisperse(dm_range, t_processed[dm_range][t], inBin.data(), dmshifts, d_input, d_output, nchans, &tsamp, dm_low.data(), dm_step.data(), ndms, nbits, failsafe);
+	dedisperse(dm_range, t_processed[dm_range][t], inBin.data(), dmshifts, d_input, d_output, NULL, nchans, &tsamp, dm_low.data(), dm_step.data(), ndms, nbits, failsafe);
 
 	//checkCudaErrors(cudaGetLastError());
 

--- a/include/aa_permitted_pipelines_generic.hpp
+++ b/include/aa_permitted_pipelines_generic.hpp
@@ -22,14 +22,13 @@
 #include "aa_device_rfi.hpp"
 #include "aa_dedisperse.hpp"
 
-#include "aa_gpu_timer.hpp"
-
 #include "aa_device_analysis.hpp"
 #include "aa_device_periods.hpp"
 #include "aa_device_acceleration_fdas.hpp"
 #include "aa_pipeline_runner.hpp"
 
 #include "aa_gpu_timer.hpp"
+#include "aa_timelog.hpp"
 
 namespace astroaccelerate {
 
@@ -54,7 +53,7 @@ namespace astroaccelerate {
 		unsigned short     const*const m_input_buffer;
 		int                num_tchunks; 
 		std::vector<float> dm_shifts; 
-		float              *dmshifts;
+		float              *dmshifts; 
 		int                maxshift; 
 		int                max_ndms; 
 		int                nchans; 
@@ -64,8 +63,9 @@ namespace astroaccelerate {
 		float              tsamp;
 		float              tsamp_original;
 		int                maxshift_original;
-		size_t             range;
+		int                nRanges;
 		float              tstart_local;
+		int                oldBin;
 
 		unsigned short     *d_DDTR_input;
 		float              *d_DDTR_output;
@@ -108,7 +108,11 @@ namespace astroaccelerate {
 
 		//Loop counter variables
 		int current_time_chunk;
+		int current_range;
+		TimeLog time_log;
 		aa_gpu_timer       m_timer;
+		aa_gpu_timer m_local_timer;
+		aa_gpu_timer m_ddtr_total_timer;
 
 		float  *m_d_MSD_workarea = NULL;
 		float  *m_d_MSD_interpolated = NULL;
@@ -155,7 +159,7 @@ namespace astroaccelerate {
 			if (e != cudaSuccess) {
 				LOG(log_level::error, "Could not allocate memory for d_DDTR_input using cudaMalloc in aa_permitted_pipelines_generic.hpp (" + std::string(cudaGetErrorString(e)) + ")");
 			}
-			
+
 			size_t gpu_outputsize = 0;
 			if (nchans < max_ndms) {
 				gpu_outputsize = (size_t)time_samps * (size_t)max_ndms * sizeof(float);
@@ -168,8 +172,8 @@ namespace astroaccelerate {
 			if (e != cudaSuccess) {
 				LOG(log_level::error, "Could not allocate memory for d_DDTR_output using cudaMalloc in aa_permitted_pipelines_generic.hpp (" + std::string(cudaGetErrorString(e)) + ")");
 			}
+
 			cudaMemset(*d_DDTR_output, 0, gpu_outputsize);
-			
 			if(nchans>8192){
 				e = cudaMalloc((void **)d_dm_shifts, nchans*sizeof(float));
 				if (e != cudaSuccess) {
@@ -220,10 +224,10 @@ namespace astroaccelerate {
 		void allocate_memory_cpu_output() {
 			size_t estimate_outputbuffer_size = 0;
 			size_t outputsize = 0;
-			const size_t range = m_ddtr_strategy.range();
+			const size_t nRanges = m_ddtr_strategy.get_nRanges();
 			const int *ndms = m_ddtr_strategy.ndms_data();
 
-			for (size_t i = 0; i < range; i++) {
+			for (size_t i = 0; i < nRanges; i++) {
 				for (int j = 0; j < m_ddtr_strategy.num_tchunks(); j++) {
 					estimate_outputbuffer_size += (size_t)(t_processed[i][j]*sizeof(float)*ndms[i]);
 				}
@@ -231,8 +235,8 @@ namespace astroaccelerate {
 
 			//if(do_copy_DDTR_data_to_host){
 				outputsize = 0;
-				m_output_buffer = (float ***)malloc(range * sizeof(float **));
-				for (size_t i = 0; i < range; i++) {
+				m_output_buffer = (float ***)malloc(nRanges * sizeof(float **));
+				for (size_t i = 0; i < nRanges; i++) {
 					int total_samps = 0;
 					for (int k = 0; k < num_tchunks; k++) {
 						total_samps += t_processed[i][k];
@@ -270,10 +274,9 @@ namespace astroaccelerate {
 			nbits = m_ddtr_strategy.metadata().nbits();
 			failsafe = 0;
 			inc = 0;
-			tsamp = m_ddtr_strategy.metadata().tsamp();
-			tsamp_original = tsamp;
+			tsamp_original = m_ddtr_strategy.metadata().tsamp();
 			maxshift_original = maxshift;
-			range = m_ddtr_strategy.range();
+			nRanges = m_ddtr_strategy.get_nRanges();
 			tstart_local = 0.0;
 
 			//Data for dedispersion
@@ -294,11 +297,11 @@ namespace astroaccelerate {
 
 			//Put the dm low, high, step struct contents into separate arrays again.
 			//This is needed so that the kernel wrapper functions don't need to be modified.
-			dm_low.resize(m_ddtr_strategy.range());
-			dm_high.resize(m_ddtr_strategy.range());
-			dm_step.resize(m_ddtr_strategy.range());
-			inBin.resize(m_ddtr_strategy.range());
-			for (size_t i = 0; i < m_ddtr_strategy.range(); i++) {
+			dm_low.resize(m_ddtr_strategy.get_nRanges());
+			dm_high.resize(m_ddtr_strategy.get_nRanges());
+			dm_step.resize(m_ddtr_strategy.get_nRanges());
+			inBin.resize(m_ddtr_strategy.get_nRanges());
+			for (size_t i = 0; i < m_ddtr_strategy.get_nRanges(); i++) {
 				dm_low[i] = m_ddtr_strategy.dm(i).low;
 				dm_high[i] = m_ddtr_strategy.dm(i).high;
 				dm_step[i] = m_ddtr_strategy.dm(i).step;
@@ -365,6 +368,7 @@ namespace astroaccelerate {
 				//------------------> End of DDTR + SPD
 				if (!did_notify_of_finishing_component) {
 					m_timer.Stop();
+					time_log.adding("Total", "total", m_timer.Elapsed());
 					float time = m_timer.Elapsed() / 1000;
 					printf("\n\n === OVERALL DEDISPERSION THROUGHPUT INCLUDING SYNCS AND DATA TRANSFERS ===\n");
 					printf("\n(Performed Brute-Force Dedispersion: %g (GPU estimate)", time);
@@ -399,48 +403,73 @@ namespace astroaccelerate {
 
 				return false; // In this case, there are no more chunks to process, and periodicity and acceleration both ran.
 			}
-			else if (current_time_chunk == 0) {
+			else if (current_time_chunk == 0 && current_range == 0) {
 				m_timer.Start();
 			}
 			
 			//----------------------------------------------------------------------->
 			//------------------> Dedispersion
-			printf("\nNOTICE: t_processed:\t%d, %d", t_processed[0][current_time_chunk], current_time_chunk);
-
 			const int *ndms = m_ddtr_strategy.ndms_data();
+				
+			if(current_range==0) {
+				m_ddtr_total_timer.Start();
+				printf("\nNOTICE: t_processed:\t%d, %d", t_processed[0][current_time_chunk], current_time_chunk);
 
-			//checkCudaErrors(cudaGetLastError());
-			load_data(-1, inBin.data(), d_DDTR_input, &m_input_buffer[(long int)(inc * nchans)], t_processed[0][current_time_chunk], maxshift, nchans, dmshifts, d_dm_shifts);
-			//checkCudaErrors(cudaGetLastError());
+				//checkCudaErrors(cudaGetLastError());
+				m_local_timer.Start();
+				load_chunk_data(d_DDTR_input, &m_input_buffer[(long int)(inc * nchans)], t_processed[0][current_time_chunk], maxshift_original, nchans, dmshifts, d_dm_shifts);
+				m_local_timer.Stop();
+				time_log.adding("DDTR", "Host_To_Device", m_local_timer.Elapsed());
+				//checkCudaErrors(cudaGetLastError());
+				
+				//---> Zero DM
+				if (m_pipeline_options.find(opt_zero_dm) != m_pipeline_options.end()) {
+					printf("\nPerforming zero DM...");
+					m_local_timer.Start();
+					zero_dm(d_DDTR_input, nchans, t_processed[0][current_time_chunk] + maxshift_original, nbits);
+					m_local_timer.Stop();
+					time_log.adding("DDTR", "Zero_DM", m_local_timer.Elapsed());
+				}
+				else if (m_pipeline_options.find(opt_zero_dm_with_outliers) != m_pipeline_options.end()) {
+					printf("\nPerforming zero dM with outliers...");
+					m_local_timer.Start();
+					zero_dm_outliers(d_DDTR_input, nchans, t_processed[0][current_time_chunk] + maxshift_original);
+					m_local_timer.Stop();
+					time_log.adding("DDTR", "Zero_DM_outliers", m_local_timer.Elapsed());
+				}
+				//-------------------<
+
+	
+				//checkCudaErrors(cudaGetLastError());
+				m_local_timer.Start();
+				corner_turn(d_DDTR_input, d_DDTR_output, nchans, t_processed[0][current_time_chunk] + maxshift_original);
+				m_local_timer.Stop();
+				time_log.adding("DDTR", "Corner_Turn", m_local_timer.Elapsed());
+
+				//checkCudaErrors(cudaGetLastError());
+
+				//---> old RFI
+				if (m_pipeline_options.find(opt_old_rfi) != m_pipeline_options.end()) {
+					printf("\nPerforming old GPU rfi...");
+					m_local_timer.Start();
+					rfi_gpu(d_DDTR_input, nchans, t_processed[0][current_time_chunk] + maxshift_original);
+					m_local_timer.Stop();
+					time_log.adding("DDTR", "RFI_GPU", m_local_timer.Elapsed());
+				}
+				//-------------------<
+
+				//checkCudaErrors(cudaGetLastError());
+				oldBin = 1;
+				m_ddtr_total_timer.Stop();
+				time_log.adding("DDTR", "total", m_ddtr_total_timer.Elapsed());
+			}
+
 			
-			//---> Zero DM
-			if (m_pipeline_options.find(opt_zero_dm) != m_pipeline_options.end()) {
-				printf("\nPerforming zero DM...");
-				zero_dm(d_DDTR_input, nchans, t_processed[0][current_time_chunk]+maxshift, nbits);
-			}
-			else if (m_pipeline_options.find(opt_zero_dm_with_outliers) != m_pipeline_options.end()) {
-				printf("\nPerforming zero dM with outliers...");
-				zero_dm_outliers(d_DDTR_input, nchans, t_processed[0][current_time_chunk]+maxshift);
-			}
-			//-------------------<
-
-			//checkCudaErrors(cudaGetLastError());
-
-			corner_turn(d_DDTR_input, d_DDTR_output, nchans, t_processed[0][current_time_chunk] + maxshift);
-
-			//checkCudaErrors(cudaGetLastError());
-
-			//---> old RFI
-			if (m_pipeline_options.find(opt_old_rfi) != m_pipeline_options.end()) {
-				printf("\nPerforming old GPU rfi...");
-				rfi_gpu(d_DDTR_input, nchans, t_processed[0][current_time_chunk]+maxshift);
-			}
-			//-------------------<
-
-			//checkCudaErrors(cudaGetLastError());
-
-			int oldBin = 1;
-			for (size_t dm_range = 0; dm_range < range; dm_range++) {
+			//for (size_t dm_range = 0; dm_range < range; dm_range++) {
+			if(current_time_chunk<num_tchunks){
+				m_ddtr_total_timer.Start();
+				int dm_range = current_range;
+				float tsamp = tsamp_original*((float) inBin[dm_range]);
 				printf("\n\nNOTICE: %f\t%f\t%f\t%d\n", m_ddtr_strategy.dm(dm_range).low, m_ddtr_strategy.dm(dm_range).high, m_ddtr_strategy.dm(dm_range).step, m_ddtr_strategy.ndms(dm_range));
 				printf("\nAmount of telescope time processed: %f\n", tstart_local);
 
@@ -448,30 +477,42 @@ namespace astroaccelerate {
 
 				cudaDeviceSynchronize();
 				//checkCudaErrors(cudaGetLastError());
-
-				load_data(dm_range, inBin.data(), d_DDTR_input, &m_input_buffer[(long int)(inc * nchans)], t_processed[dm_range][current_time_chunk], maxshift, nchans, dmshifts, d_dm_shifts);
+				m_local_timer.Start();
+				set_dedispersion_constants(t_processed[dm_range][current_time_chunk], maxshift);
+				m_local_timer.Stop();
+				time_log.adding("DDTR", "Host_To_Device",m_local_timer.Elapsed());
 
 				//checkCudaErrors(cudaGetLastError());
 
-
+				
 				if (inBin[dm_range] > oldBin) {
+					m_local_timer.Start();
 					bin_gpu(d_DDTR_input, d_DDTR_output, nchans, t_processed[dm_range - 1][current_time_chunk] + maxshift * inBin[dm_range]);
-					(tsamp) = (tsamp) * 2.0f;
+					m_local_timer.Stop();
+					time_log.adding("DDTR", "Binning",m_local_timer.Elapsed());
 				}
 
 				//checkCudaErrors(cudaGetLastError());
-				
+				m_local_timer.Start();
 				dedisperse(dm_range, t_processed[dm_range][current_time_chunk], inBin.data(), dmshifts, d_DDTR_input, d_DDTR_output, d_dm_shifts, nchans, &tsamp, dm_low.data(), dm_step.data(), ndms, nbits, failsafe);
+				m_local_timer.Stop();
+				time_log.adding("DDTR","Dedispersion",m_local_timer.Elapsed());
 
 				//checkCudaErrors(cudaGetLastError());
 				
 				//-----------> Copy data to the host
 				if(do_copy_DDTR_data_to_host){
+					m_local_timer.Start();
 					for (int k = 0; k < ndms[dm_range]; k++) {
 						save_data_offset(d_DDTR_output, k * t_processed[dm_range][current_time_chunk], m_output_buffer[dm_range][k], inc / inBin[dm_range], sizeof(float) * t_processed[dm_range][current_time_chunk]);
 					}
+					m_local_timer.Stop();
+					time_log.adding("DDTR", "Device_To_Host", m_local_timer.Elapsed());
 				}
+				m_ddtr_total_timer.Stop();
+				time_log.adding("DDTR", "total", m_ddtr_total_timer.Elapsed());
 				//--------------------------------------------<
+
 				
 
 				//------------------> Single pulse detection
@@ -513,18 +554,20 @@ namespace astroaccelerate {
 						output);
 				}
 				//--------------------------------------------------------------------------------<
-
 				oldBin = inBin[dm_range];
 			}
 
-			inc = inc + t_processed[0][current_time_chunk];
-			printf("\nNOTICE: INC:\t%ld\n", inc);
-			tstart_local = (tsamp_original * inc);
-			tsamp = tsamp_original;
-			maxshift = maxshift_original;
-
-			++current_time_chunk;
-			printf("NOTICE: Pipeline ended run_pipeline_5 over chunk %d / %d.\n", current_time_chunk, num_tchunks);
+			printf("NOTICE: Pipeline ended run_pipeline_generic over chunk %d / %d and range %d / %d.\n", current_time_chunk, num_tchunks, current_range, nRanges);
+			
+			++current_range;
+			if(current_range>=nRanges) {
+				inc = inc + t_processed[0][current_time_chunk];
+				tstart_local = (tsamp_original * inc);
+				printf("\nNOTICE: INC:\t%ld\n", inc);
+				++current_time_chunk;
+				current_range = 0;
+			}
+			
 			status_code = aa_pipeline_runner::status::has_more;
 			return true;
 		}
@@ -534,7 +577,7 @@ namespace astroaccelerate {
 			aa_gpu_timer timer;
 			timer.Start();
 			const int *ndms = m_ddtr_strategy.ndms_data();
-			GPU_periodicity(m_ddtr_strategy.range(),
+			GPU_periodicity(m_ddtr_strategy.get_nRanges(),
 				m_ddtr_strategy.metadata().nsamples(),
 				max_ndms,
 				inc,
@@ -552,6 +595,8 @@ namespace astroaccelerate {
 				m_periodicity_strategy.sigma_constant());
 
 			timer.Stop();
+			time_log.adding("Periodicity", "total", timer.Elapsed());
+
 			float time = timer.Elapsed()/1000;
 			printf("\n\n === OVERALL PERIODICITY THROUGHPUT INCLUDING SYNCS AND DATA TRANSFERS ===\n");
 
@@ -571,7 +616,7 @@ namespace astroaccelerate {
 			timer.Start();
 			const int *ndms = m_ddtr_strategy.ndms_data();
 
-			acceleration_fdas(m_ddtr_strategy.range(),
+			acceleration_fdas(m_ddtr_strategy.get_nRanges(),
 				m_ddtr_strategy.metadata().nsamples(),
 				max_ndms,
 				inc,
@@ -591,6 +636,7 @@ namespace astroaccelerate {
 				m_fdas_enable_output_list);
 
 			timer.Stop();
+			time_log.adding("FDAS", "total", timer.Elapsed());
 			float time = timer.Elapsed()/1000;
 			printf("\n\n === OVERALL TDAS THROUGHPUT INCLUDING SYNCS AND DATA TRANSFERS ===\n");
 
@@ -646,6 +692,7 @@ namespace astroaccelerate {
 		acceleration_did_run(false),
 		did_notify_of_finishing_component(false),
 		current_time_chunk(0),
+		current_range(0),
 		m_d_MSD_workarea(NULL),
 		m_d_MSD_interpolated(NULL),
 		m_d_MSD_output_taps(NULL) {
@@ -697,7 +744,6 @@ namespace astroaccelerate {
 				aa_pipeline_runner::status tmp;
 				return run_pipeline(tmp);
 			}
-
 			return false;
 		}
 
@@ -706,35 +752,76 @@ namespace astroaccelerate {
 			if (memory_allocated) {
 				return run_pipeline(status_code);
 			}
-
 			return false;
+		}
+
+
+		/**
+		 * \brief Return the pointer to the complete dedispersed output data.
+		 * \details The array data is only useful once the pipeline has finished running.
+		 * \details Users should finish running the pipeline so that all dedispersion output is available.
+		 * \details Alternatively, the user may access the data one time chunk at a time, but the next time chunk will not have been computed yet.
+		 * \details The structure of the ddtr output buffer data is indexed by: time_chunk index, dm_range index, dm.
+		 */
+		float*** output_buffer() {
+			if(memory_allocated) {
+				return m_output_buffer;
+			}
+			return NULL;
+		}
+
+		float* h_SPD_snr(){
+			if(memory_allocated && !memory_cleanup){
+				return h_SPD_candidate_list_SNR;
+			}
+			return NULL;
+		}
+
+		unsigned int* h_SPD_ts(){
+			if(memory_allocated && !memory_cleanup){
+					return h_SPD_candidate_list_TS;
+			}
+			return NULL;
+		}
+
+		unsigned int* h_SPD_dm(){
+			if(memory_allocated && !memory_cleanup){
+					return h_SPD_candidate_list_DM;
+			}
+			return NULL;
+		}
+
+		unsigned int* h_SPD_width(){
+			if(memory_allocated && !memory_cleanup){
+					return h_SPD_candidate_list_BW;
+			}
+			return NULL;
+		}
+
+		size_t get_SPD_nCandidates(){
+			return SPD_nCandidates;
+		}
+
+		int get_current_range(){
+			return (current_range>0 ? current_range-1:nRanges-1);
+		}
+
+		int get_current_tchunk(){
+			return (current_range>0 ? current_time_chunk:current_time_chunk-1);
+		}
+
+		long int get_current_inc(){
+			return inc;
 		}
 
 		/** \brief De-allocate memory for this pipeline instance. */
 		bool cleanup() {
 			if (memory_allocated && !memory_cleanup) {
 				LOG(log_level::debug, "Generic Pipeline -> Memory cleanup at the end of the pipeline");
-				/*
-				cudaFree(d_DDTR_input);
-				cudaFree(d_DDTR_output);
-				
-				if(do_single_pulse_detection){
-					cudaFree(m_d_MSD_workarea);
-					cudaFree(m_d_MSD_output_taps);
-					cudaFree(m_d_MSD_interpolated);
-				}
-				
-				// Why this is not in the ddtr_strategy?
-				size_t t_processed_size = m_ddtr_strategy.t_processed().size();
-				for (size_t i = 0; i < t_processed_size; i++) {
-					free(t_processed[i]);
-				}
-				free(t_processed);
-				*/
 
 				if(do_copy_DDTR_data_to_host) {
 					const int *ndms = m_ddtr_strategy.ndms_data();
-					for (size_t i = 0; i < range; i++) {
+					for (int i = 0; i < nRanges; i++) {
 						for (int j = 0; j < ndms[i]; j++) {
 							free(m_output_buffer[i][j]);
 						}
@@ -745,14 +832,20 @@ namespace astroaccelerate {
 
 				memory_cleanup = true;
 			}
+			
+			if (m_pipeline_options.find(aa_pipeline::component_option::timelog_export_to_file) != m_pipeline_options.end()) {
+				time_log.print_to_file();
+			}
+			
+			time_log.print();
+
 			return true;
 		}
-	
 		
 	}; // class end
-	
 
 } // namespace astroaccelerate
 
 #endif // ASTRO_ACCELERATE_AA_PERMITTED_PIPELINES_GENERIC_HPP
+
 

--- a/include/aa_permitted_pipelines_generic.hpp
+++ b/include/aa_permitted_pipelines_generic.hpp
@@ -145,7 +145,7 @@ namespace astroaccelerate {
 		}
 		
 		/** \brief Allocate the GPU memory needed for dedispersion. */
-		void allocate_gpu_memory_DDTR(const int &maxshift, const int &max_ndms, const int &nchans, int **const t_processed, unsigned short **const d_DDTR_input, float **const d_DDTR_output) {
+		void allocate_gpu_memory_DDTR(const int &maxshift, const int &max_ndms, const int &nchans, int **const t_processed, unsigned short **const d_DDTR_input, float **const d_DDTR_output, float **const d_dm_shifts) {
 			int time_samps = t_processed[0][0] + maxshift;
 			printf("\n\n\n%d\n\n\n", time_samps);
 			size_t gpu_inputsize = (size_t)time_samps * (size_t)nchans * sizeof(unsigned short);
@@ -282,7 +282,7 @@ namespace astroaccelerate {
 			d_dm_shifts = NULL;
 
 			//Allocate GPU memory for dedispersion
-			allocate_gpu_memory_DDTR(maxshift, max_ndms, nchans, t_processed, &d_DDTR_input, &d_DDTR_output);
+			allocate_gpu_memory_DDTR(maxshift, max_ndms, nchans, t_processed, &d_DDTR_input, &d_DDTR_output, &d_dm_shifts);
 			
 			//Allocate GPU memory for SPD (i.e. analysis)
 			if(do_single_pulse_detection) {

--- a/src/aa_dedisperse.cpp
+++ b/src/aa_dedisperse.cpp
@@ -2,11 +2,9 @@
 
 namespace astroaccelerate {
 
-void dedisperse(int i, int t_processed, int *inBin, float *dmshifts, unsigned short *d_input, float *d_output, int nchans, float *tsamp, float *dm_low, float *dm_step, int const*const ndms, int nbits, int failsafe) {    
-  if (failsafe == 0)
-    {
-      if(nbits == 16 || nbits == 32)
-	{
+void dedisperse(int i, int t_processed, int *inBin, float *dmshifts, unsigned short *d_input, float *d_output, float *d_dm_shifts, int nchans, float *tsamp, float *dm_low, float *dm_step, int const*const ndms, int nbits, int failsafe) {    
+  if (failsafe == 0) {
+      if(nbits == 16 || nbits == 32) {
 	  float shift_one = ( SDIVINDM - 1 ) * ( dm_step[i] / ( *tsamp ) );
 	  int shifta = (int) floorf(shift_one * dmshifts[nchans - 1]) + ( SDIVINT - 1 ) * 2;
 	  int lineshift = shifta + ( ( SNUMREG - 1 ) * 2 * SDIVINT );
@@ -18,8 +16,7 @@ void dedisperse(int i, int t_processed, int *inBin, float *dmshifts, unsigned sh
 	  // Check to see if the threadblock will load a shared memory line that
 	  // is long enough for the algorithm to run without an out of bounds
 	  // access...
-	  if (( ( SDIVINT - 1 ) + ( ( SDIVINDM - 1 ) * SDIVINT ) - 1 ) > lineshift)
-	    {
+	  if (( ( SDIVINT - 1 ) + ( ( SDIVINDM - 1 ) * SDIVINT ) - 1 ) > lineshift) {
 
 	      printf("\nUsing fast shared memory kernel");
 
@@ -36,16 +33,19 @@ void dedisperse(int i, int t_processed, int *inBin, float *dmshifts, unsigned sh
 
 	      cudaDeviceSetSharedMemConfig (cudaSharedMemBankSizeFourByte);
 	      //cudaFuncSetCacheConfig(shared_dedisperse_kernel_16, cudaFuncCachePreferShared); //Subsume in call_kernel_*
-	      call_kernel_shared_dedisperse_kernel_16(num_blocks, threads_per_block, inBin[i], d_input, d_output, (float) ( startdm / ( *tsamp ) ), (float) ( dm_step[i] / ( *tsamp ) ));
+	      if(nchans>8192){
+			  call_kernel_shared_dedisperse_kernel_16_nchan8192p(num_blocks, threads_per_block, inBin[i], d_input, d_output, d_dm_shifts, (float) ( startdm / ( *tsamp ) ), (float) ( dm_step[i] / ( *tsamp ) ));
+		  }
+		  else {
+			  call_kernel_shared_dedisperse_kernel_16(num_blocks, threads_per_block, inBin[i], d_input, d_output, (float) ( startdm / ( *tsamp ) ), (float) ( dm_step[i] / ( *tsamp ) ));
+		  }
 	    }
-	  else
-	    {
+	  else {
 	      printf("\nERROR: smem line length is too short.\nRun the auto tuner again!\n");
 	      failsafe = 1;
 	    }
 	}
-      else
-	{
+      else {
 	  // FOR KEPLER SMEM....
 	  float shift_one = ( SDIVINDM - 1 ) * ( dm_step[i] / ( *tsamp ) );
 	  int shifta = (int) floorf(shift_one * dmshifts[nchans - 1]) + ( SDIVINT - 1 ) * 2;
@@ -58,8 +58,7 @@ void dedisperse(int i, int t_processed, int *inBin, float *dmshifts, unsigned sh
 	  // Check to see if the threadblock will load a shared memory line that
 	  // is long enough for the algorithm to run without an out of bounds
 	  // access...
-	  if (( ( SDIVINT - 1 ) + ( ( SDIVINDM - 1 ) * SDIVINT ) - 1 ) > lineshift)
-	    {
+	  if (( ( SDIVINT - 1 ) + ( ( SDIVINDM - 1 ) * SDIVINT ) - 1 ) > lineshift) {
 
 	      printf("\nUsing fast shared memory kernel");
 
@@ -76,18 +75,21 @@ void dedisperse(int i, int t_processed, int *inBin, float *dmshifts, unsigned sh
 
 	      cudaDeviceSetSharedMemConfig (cudaSharedMemBankSizeFourByte);
 	      //cudaFuncSetCacheConfig(shared_dedisperse_kernel, cudaFuncCachePreferShared); //Subsume in call_kernel_*
-	      call_kernel_shared_dedisperse_kernel(num_blocks, threads_per_block, inBin[i], d_input, d_output, (float) ( startdm / ( *tsamp ) ), (float) ( dm_step[i] / ( *tsamp ) ));
+	      if(nchans>8192) {
+			  call_kernel_shared_dedisperse_kernel_nchan8192p(num_blocks, threads_per_block, inBin[i], d_input, d_output, d_dm_shifts, (float) ( startdm / ( *tsamp ) ), (float) ( dm_step[i] / ( *tsamp ) ));
+		  }
+		  else {
+			  call_kernel_shared_dedisperse_kernel(num_blocks, threads_per_block, inBin[i], d_input, d_output, (float) ( startdm / ( *tsamp ) ), (float) ( dm_step[i] / ( *tsamp ) ));
+		  }
 	    }
-	  else
-	    {
+	  else {
 	      printf("\nERROR: smem line length is too short.\nRun the auto tuner again!\n");
 	      failsafe = 1;
 	    }
 
 	}
     }
-  if(failsafe != 0)
-    {
+  if(failsafe != 0) {
       printf("\nUsing fallback failsafe kernel");
 
       //{{{ Dedisperse data on the GPU

--- a/src/aa_dedisperse.cpp
+++ b/src/aa_dedisperse.cpp
@@ -34,7 +34,6 @@ void dedisperse(int i, int t_processed, int *inBin, float *dmshifts, unsigned sh
 	      cudaDeviceSetSharedMemConfig (cudaSharedMemBankSizeFourByte);
 	      //cudaFuncSetCacheConfig(shared_dedisperse_kernel_16, cudaFuncCachePreferShared); //Subsume in call_kernel_*
 	      if(nchans>8192){
-			  printf("Calling DDTR for 16k+\n");
 			  call_kernel_shared_dedisperse_kernel_16_nchan8192p(num_blocks, threads_per_block, inBin[i], d_input, d_output, d_dm_shifts, (float) ( startdm / ( *tsamp ) ), (float) ( dm_step[i] / ( *tsamp ) ));
 		  }
 		  else {
@@ -77,7 +76,6 @@ void dedisperse(int i, int t_processed, int *inBin, float *dmshifts, unsigned sh
 	      cudaDeviceSetSharedMemConfig (cudaSharedMemBankSizeFourByte);
 	      //cudaFuncSetCacheConfig(shared_dedisperse_kernel, cudaFuncCachePreferShared); //Subsume in call_kernel_*
 	      if(nchans>8192) {
-			  printf("Calling DDTR for 16k+\n");
 			  call_kernel_shared_dedisperse_kernel_nchan8192p(num_blocks, threads_per_block, inBin[i], d_input, d_output, d_dm_shifts, (float) ( startdm / ( *tsamp ) ), (float) ( dm_step[i] / ( *tsamp ) ));
 		  }
 		  else {
@@ -107,7 +105,12 @@ void dedisperse(int i, int t_processed, int *inBin, float *dmshifts, unsigned sh
       dim3 num_blocks(num_blocks_t, num_blocks_dm);
 
       //cudaFuncSetCacheConfig(cache_dedisperse_kernel, cudaFuncCachePreferL1); //Subsume in call_kernel_*
-      call_kernel_cache_dedisperse_kernel(num_blocks, threads_per_block, inBin[i], d_input, d_output, (float) ( startdm / ( *tsamp ) ), (float) ( dm_step[i] / ( *tsamp ) ));
+	if(nchans>8192) {
+		call_kernel_cache_dedisperse_kernel_nchan8192p(num_blocks, threads_per_block, inBin[i], d_input, d_output, d_dm_shifts, (float) ( startdm / ( *tsamp ) ), (float) ( dm_step[i] / ( *tsamp ) ));
+	}
+	else {
+		call_kernel_cache_dedisperse_kernel(num_blocks, threads_per_block, inBin[i], d_input, d_output, (float) ( startdm / ( *tsamp ) ), (float) ( dm_step[i] / ( *tsamp ) ));
+	}
     }
 }
 

--- a/src/aa_dedisperse.cpp
+++ b/src/aa_dedisperse.cpp
@@ -34,6 +34,7 @@ void dedisperse(int i, int t_processed, int *inBin, float *dmshifts, unsigned sh
 	      cudaDeviceSetSharedMemConfig (cudaSharedMemBankSizeFourByte);
 	      //cudaFuncSetCacheConfig(shared_dedisperse_kernel_16, cudaFuncCachePreferShared); //Subsume in call_kernel_*
 	      if(nchans>8192){
+			  printf("Calling DDTR for 16k+\n");
 			  call_kernel_shared_dedisperse_kernel_16_nchan8192p(num_blocks, threads_per_block, inBin[i], d_input, d_output, d_dm_shifts, (float) ( startdm / ( *tsamp ) ), (float) ( dm_step[i] / ( *tsamp ) ));
 		  }
 		  else {
@@ -76,6 +77,7 @@ void dedisperse(int i, int t_processed, int *inBin, float *dmshifts, unsigned sh
 	      cudaDeviceSetSharedMemConfig (cudaSharedMemBankSizeFourByte);
 	      //cudaFuncSetCacheConfig(shared_dedisperse_kernel, cudaFuncCachePreferShared); //Subsume in call_kernel_*
 	      if(nchans>8192) {
+			  printf("Calling DDTR for 16k+\n");
 			  call_kernel_shared_dedisperse_kernel_nchan8192p(num_blocks, threads_per_block, inBin[i], d_input, d_output, d_dm_shifts, (float) ( startdm / ( *tsamp ) ), (float) ( dm_step[i] / ( *tsamp ) ));
 		  }
 		  else {

--- a/src/aa_device_dedispersion_kernel.cu
+++ b/src/aa_device_dedispersion_kernel.cu
@@ -10,8 +10,7 @@ namespace astroaccelerate {
   __device__ __constant__ int i_nsamp, i_nchans, i_t_processed_s;
   __device__ __constant__ float dm_shifts[8192];
 
-  __global__ void shared_dedisperse_kernel(int bin, unsigned short *d_input, float *d_output, float mstartdm, float mdmstep)
-  {
+  __global__ void shared_dedisperse_kernel(int bin, unsigned short *d_input, float *d_output, float mstartdm, float mdmstep) {
     ushort temp_f;
 
     int i, j, c, local, unroll, stage;
@@ -79,8 +78,70 @@ namespace astroaccelerate {
   }
 
 
-  __global__ void shared_dedisperse_kernel_16(int bin, unsigned short *d_input, float *d_output, float mstartdm, float mdmstep)
-  {
+
+	__global__ void shared_dedisperse_kernel_nchan8192p(int bin, unsigned short *d_input, float *d_output, float *d_dm_shifts, float mstartdm, float mdmstep) {
+		ushort temp_f;
+		
+		int i, j, c, local, unroll, stage;
+		
+		int shift[UNROLLS];
+		int local_kernel_one[SNUMREG];
+		int local_kernel_two[SNUMREG];
+		
+		float findex = (( threadIdx.x * 2 ) + 1 );
+		
+		for (i = 0; i < SNUMREG; i++) {
+			local_kernel_one[i] = 0;
+			local_kernel_two[i] = 0;
+		}
+		
+		int idx 	  = ( threadIdx.x + ( threadIdx.y * SDIVINT ) );
+		int nsamp_counter = ( idx + ( blockIdx.x * ( 2 * SNUMREG * SDIVINT ) ) );
+		
+		float shift_two = ( mstartdm + ( __int2float_rz(blockIdx.y) * SFDIVINDM * mdmstep ) );
+		float shift_one = ( __int2float_rz(threadIdx.y) * mdmstep );
+		
+		for (c = 0; c < i_nchans; c += UNROLLS) {
+			
+			__syncthreads();
+			
+			for (j = 0; j < UNROLLS; j++) {
+				temp_f = ( __ldg(( d_input + ( __float2int_rz(d_dm_shifts[c + j] * shift_two) ) )  + ( nsamp_counter + ( j * i_nsamp ) )) );
+				
+				f_line[j][idx + 1].x = temp_f;
+				f_line[j][idx    ].y = temp_f;
+				
+				shift[j] = __float2int_rz(shift_one * d_dm_shifts[c + j] + findex);
+			}
+			
+			nsamp_counter = ( nsamp_counter + ( UNROLLS * i_nsamp ) );
+			
+			__syncthreads();
+		
+			for (i = 0; i < SNUMREG; i++) {
+				local = 0;
+				unroll = ( i * 2 * SDIVINT );
+				for (j = 0; j < UNROLLS; j++) {
+					stage = *(int*) &f_line[j][( shift[j] + unroll )];
+					local += stage;
+				}
+				local_kernel_one[i] += (local & 0x0000FFFF);
+				local_kernel_two[i] += (local & 0xFFFF0000) >> 16;
+			}
+		}
+		
+		// Write the accumulators to the output array. 
+		local = ( ( ( ( blockIdx.y * SDIVINDM ) + threadIdx.y ) * ( i_t_processed_s ) ) + ( blockIdx.x * 2 * SNUMREG * SDIVINT ) ) + 2 * threadIdx.x;
+		
+		#pragma unroll
+		for (i = 0; i < SNUMREG; i++) {
+			*( (float2*) ( d_output + local + ( i * 2 * SDIVINT ) ) ) = make_float2((float)local_kernel_one[i]/i_nchans/bin, (float)local_kernel_two[i]/i_nchans/bin);
+		}
+	}
+
+
+
+  __global__ void shared_dedisperse_kernel_16(int bin, unsigned short *d_input, float *d_output, float mstartdm, float mdmstep) {
     int i, c;
     int shift;
 
@@ -140,8 +201,7 @@ namespace astroaccelerate {
       }
   }
 
-  __global__ void cache_dedisperse_kernel(int bin, unsigned short *d_input, float *d_output, float mstartdm, float mdmstep)
-  {
+  __global__ void cache_dedisperse_kernel(int bin, unsigned short *d_input, float *d_output, float mstartdm, float mdmstep) {
     int   shift;	
     float local_kernel;
 
@@ -171,6 +231,65 @@ namespace astroaccelerate {
 
   }
 
+  
+	__global__ void shared_dedisperse_kernel_16_nchan8192p(int bin, unsigned short *d_input, float *d_output, float *d_dm_shifts, float mstartdm, float mdmstep) {
+		int i, c;
+		int shift;
+		
+		ushort temp_f;
+		int local, unroll;
+		
+		float findex = ( threadIdx.x * 2 );
+		float local_kernel_one[SNUMREG];
+		float local_kernel_two[SNUMREG];
+		
+		for (i = 0; i < SNUMREG; i++) {
+			local_kernel_one[i] = 0.0f;
+			local_kernel_two[i] = 0.0f;
+		}
+		
+		int idx = ( threadIdx.x + ( threadIdx.y * SDIVINT ) );
+		int nsamp_counter = ( idx + ( blockIdx.x * ( 2 * SNUMREG * SDIVINT ) ) );
+		
+		float shift_two = ( mstartdm + ( __int2float_rz(blockIdx.y) * SFDIVINDM * mdmstep ) );
+		float shift_one = ( __int2float_rz(threadIdx.y) * mdmstep );
+		
+		for (c = 0; c < i_nchans; c ++) {
+			
+			__syncthreads();
+			
+			temp_f = ( __ldg(( d_input + ( __float2int_rz(dm_shifts[c] * shift_two) ) ) + ( nsamp_counter )) );
+			
+			f_line[0][idx].x = temp_f;
+			if (idx > 0) {
+				f_line[0][idx - 1].y = temp_f;
+			}
+			shift = __float2int_rz(shift_one * dm_shifts[c] + findex);
+			
+			nsamp_counter = ( nsamp_counter + i_nsamp );
+			
+			__syncthreads();
+			
+			for (i = 0; i < SNUMREG; i++) {
+				unroll = ( i * 2 * SDIVINT );
+				local = *(int*) &f_line[0][( shift + unroll )];
+				local_kernel_one[i] += ( (ushort2*) ( &local ) )->x;
+				local_kernel_two[i] += ( (ushort2*) ( &local ) )->y;
+			}
+		}
+		
+		// Write the accumulators to the output array. 
+		local = ( ( ( ( blockIdx.y * SDIVINDM ) + threadIdx.y ) * ( i_t_processed_s ) ) + ( blockIdx.x * 2 * SNUMREG * SDIVINT ) ) + 2 * threadIdx.x;
+		
+		#pragma unroll
+		for (i = 0; i < SNUMREG; i++) {
+			*( (float2*) ( d_output + local + ( i * 2 * SDIVINT ) ) ) = make_float2(local_kernel_one[i]/i_nchans/bin, local_kernel_two[i]/i_nchans/bin);
+		}
+	}
+
+  
+  
+  
   /** \brief Kernel wrapper function to set device constants for dedispersion_kernel kernel function. */
   void set_device_constants_dedispersion_kernel(const int &nchans, const int &length, const int &t_processed, const float *const dmshifts) {
     cudaMemcpyToSymbol(dm_shifts, dmshifts, nchans * sizeof(float));
@@ -192,6 +311,13 @@ namespace astroaccelerate {
     cudaFuncSetCacheConfig(shared_dedisperse_kernel, cudaFuncCachePreferShared);
     shared_dedisperse_kernel<<<block_size, grid_size>>>(bin, d_input, d_output, mstartdm, mdmstep);
   }
+  
+	/** \brief Kernel wrapper function for dedispersion GPU kernel which works with number of channels greater than 8192. */
+	void call_kernel_shared_dedisperse_kernel_nchan8192p(const dim3 &block_size, const dim3 &grid_size, const int &bin, unsigned short *const d_input, float *const d_output, float *const d_dm_shifts, const float &mstartdm, const float &mdmstep) {
+		cudaFuncSetCacheConfig(shared_dedisperse_kernel_nchan8192p, cudaFuncCachePreferShared);
+		shared_dedisperse_kernel_nchan8192p<<<block_size, grid_size>>>(bin, d_input, d_output, d_dm_shifts, mstartdm, mdmstep);
+	}
+  
 
   /** \brief Kernel wrapper function for dedisperse_kernel_16 kernel function. */
   void call_kernel_shared_dedisperse_kernel_16(const dim3 &block_size, const dim3 &grid_size,
@@ -199,6 +325,12 @@ namespace astroaccelerate {
     cudaFuncSetCacheConfig(shared_dedisperse_kernel_16, cudaFuncCachePreferShared);
     shared_dedisperse_kernel_16<<<block_size, grid_size>>>(bin, d_input, d_output, mstartdm, mdmstep);
   }
+  
+	/** \brief Kernel wrapper function for dedispersion kernel which works with 16bit data and when number of channels is greater than 8192 kernel function. */
+	void call_kernel_shared_dedisperse_kernel_16_nchan8192p(const dim3 &block_size, const dim3 &grid_size, const int &bin, unsigned short *const d_input, float *const d_output, float *const d_dm_shifts, const float &mstartdm, const float &mdmstep) {
+		cudaFuncSetCacheConfig(shared_dedisperse_kernel_16_nchan8192p, cudaFuncCachePreferShared);
+		shared_dedisperse_kernel_16<<<block_size, grid_size>>>(bin, d_input, d_output, mstartdm, mdmstep);
+	}
 
   /** \brief Kernel wrapper function for cache_dedisperse_kernel kernel function. */
   void call_kernel_cache_dedisperse_kernel(const dim3 &block_size, const dim3 &grid_size,

--- a/src/aa_device_dedispersion_kernel.cu
+++ b/src/aa_device_dedispersion_kernel.cu
@@ -258,13 +258,13 @@ namespace astroaccelerate {
 			
 			__syncthreads();
 			
-			temp_f = ( __ldg(( d_input + ( __float2int_rz(dm_shifts[c] * shift_two) ) ) + ( nsamp_counter )) );
+			temp_f = ( __ldg(( d_input + ( __float2int_rz(d_dm_shifts[c] * shift_two) ) ) + ( nsamp_counter )) );
 			
 			f_line[0][idx].x = temp_f;
 			if (idx > 0) {
 				f_line[0][idx - 1].y = temp_f;
 			}
-			shift = __float2int_rz(shift_one * dm_shifts[c] + findex);
+			shift = __float2int_rz(shift_one * d_dm_shifts[c] + findex);
 			
 			nsamp_counter = ( nsamp_counter + i_nsamp );
 			

--- a/src/aa_device_load_data.cu
+++ b/src/aa_device_load_data.cu
@@ -19,7 +19,6 @@ namespace astroaccelerate {
       cudaMemcpy(device_pointer, host_pointer, size, cudaMemcpyHostToDevice);
       //checkCudaErrors(cudaGetLastError());
       if(nchans>8192) {
-		  printf("Copy dm_shifts to the device\n");
 			cudaMemcpy(d_dm_shifts, dmshifts, nchans*sizeof(float), cudaMemcpyHostToDevice);
 	  }
 	  set_device_constants_dedispersion_kernel(nchans, length, t_processed, dmshifts);

--- a/src/aa_device_load_data.cu
+++ b/src/aa_device_load_data.cu
@@ -19,6 +19,7 @@ namespace astroaccelerate {
       cudaMemcpy(device_pointer, host_pointer, size, cudaMemcpyHostToDevice);
       //checkCudaErrors(cudaGetLastError());
       if(nchans>8192) {
+		  printf("Copy dm_shifts to the device\n");
 			cudaMemcpy(d_dm_shifts, dmshifts, nchans*sizeof(float), cudaMemcpyHostToDevice);
 	  }
 	  else {

--- a/src/aa_device_load_data.cu
+++ b/src/aa_device_load_data.cu
@@ -22,9 +22,7 @@ namespace astroaccelerate {
 		  printf("Copy dm_shifts to the device\n");
 			cudaMemcpy(d_dm_shifts, dmshifts, nchans*sizeof(float), cudaMemcpyHostToDevice);
 	  }
-	  else {
-		  set_device_constants_dedispersion_kernel(nchans, length, t_processed, dmshifts);
-	  }
+	  set_device_constants_dedispersion_kernel(nchans, length, t_processed, dmshifts);
     }
     else if(i > 0) {
       const long int length = ( t_processed + maxshift );

--- a/src/aa_device_load_data.cu
+++ b/src/aa_device_load_data.cu
@@ -11,14 +11,19 @@ namespace astroaccelerate {
    * \warning If the file extension of this file is *.cpp, then the code will compile but there will be a runtime CUDA error when copying to device memory.
    */
   
-  void load_data(int i, int *inBin, unsigned short *device_pointer, unsigned short const*const host_pointer, int t_processed, int maxshift, int nchans, float *dmshifts) {
+  void load_data(int i, int *inBin, unsigned short *device_pointer, unsigned short const*const host_pointer, int t_processed, int maxshift, int nchans, float *dmshifts, float *d_dm_shifts) {
     if(i == -1) {
       const long int length = ( t_processed + maxshift );
       const size_t size = (size_t)nchans * (size_t)length * (size_t)sizeof(unsigned short);
       //checkCudaErrors(cudaGetLastError());
       cudaMemcpy(device_pointer, host_pointer, size, cudaMemcpyHostToDevice);
       //checkCudaErrors(cudaGetLastError());
-      set_device_constants_dedispersion_kernel(nchans, length, t_processed, dmshifts);
+      if(nchans>8192) {
+			cudaMemcpy(d_dm_shifts, dmshifts, nchans*sizeof(float), cudaMemcpyHostToDevice);
+	  }
+	  else {
+		  set_device_constants_dedispersion_kernel(nchans, length, t_processed, dmshifts);
+	  }
     }
     else if(i > 0) {
       const long int length = ( t_processed + maxshift );


### PR DESCRIPTION
---
name: De-dispersion kernels for more then 8192 channels
about: Adds modified de-dispersion kernels which can process more then 8192 channels.

---

**Description of pull request**


**Interfaces**
Will this pull request result in a backwards-incompatible interface change: No

Expected semantic version number increment category (Please indicate x.y.z): y


**Issues this pull request solves**


**New tag of master**


**New deployment**


**Keep branch after merging**


**Notes**
