### PR TITLE
changing the skeleton header used for autotune with missing parameters

### DIFF
--- a/lib/header
+++ b/lib/header
@@ -77,6 +77,12 @@ namespace astroaccelerate {
 #define DIT_YSTEP 2
 #define DIT_ELEMENTS_PER_THREAD 4
 
+//experimental clustering filter
+#define PPF_PEAKS_PER_BLOCK 10
+#define PPF_DPB 128
+//radius of search for peak filtering in miliseconds
+#define PPF_SEARCH_RANGE_IN_MS 15
+
 #define PPF_L1_THREADS_PER_BLOCK 256
 #define PPF_L1_SPECTRA_PER_BLOCK 5
 


### PR DESCRIPTION
---
name: Pull Request
about: Missing variables in the header for aa_params.hpp

---

**Description of pull request**
Repairing bug #211

**Interfaces**
Will this pull request result in a backwards-incompatible interface change:no

Expected semantic version number increment category (Please indicate x.y.z):z


**Issues this pull request solves**
#211 

**New tag of master**


**New deployment**


**Keep branch after merging**
no

**Notes**
