### PR TITLE
Added spectrum whitening

### DIFF
--- a/include/aa_device_spectrum_whitening.hpp
+++ b/include/aa_device_spectrum_whitening.hpp
@@ -1,0 +1,14 @@
+#ifndef ASTRO_ACCELERATE_AA_DEVICE_SPECTRUM_WHITENING_HPP
+#define ASTRO_ACCELERATE_AA_DEVICE_SPECTRUM_WHITENING_HPP
+
+#include <cufft.h>
+
+namespace astroaccelerate {
+
+extern void spectrum_whitening_SGP1(float *d_input, unsigned long int nSamples, int nDMs, cudaStream_t &stream);
+
+
+} // namespace astroaccelerate
+  
+#endif // ASTRO_ACCELERATE_AA_DEVICE_SPECTRUM_WHITENING_HPP
+

--- a/include/aa_device_spectrum_whitening_kernel.hpp
+++ b/include/aa_device_spectrum_whitening_kernel.hpp
@@ -1,0 +1,18 @@
+#ifndef ASTRO_ACCELERATE_AA_DEVICE_SPECTRUM_WHITENING_KERNEL_HPP
+#define ASTRO_ACCELERATE_AA_DEVICE_SPECTRUM_WHITENING_KERNEL_HPP
+
+namespace astroaccelerate {
+
+	/** \brief Kernel wrapper function for spectral whitening kernel function. */
+	void call_kernel_spectrum_whitening_SGP1(
+		const dim3 &block_size, 
+		const dim3 &grid_size, 
+		const int &smem_bytes, 
+		const cudaStream_t &stream, 
+		float *d_input, 
+		unsigned long int nSamples
+	);
+
+} // namespace astroaccelerate
+  
+#endif // ASTRO_ACCELERATE_AA_DEVICE_SPECTRUM_WHITENING_KERNEL_HPP

--- a/src/aa_device_periods.cu
+++ b/src/aa_device_periods.cu
@@ -16,6 +16,7 @@
 #include "aa_device_MSD_plane_profile.hpp"
 #include "aa_device_peak_find.hpp"
 #include "aa_device_power.hpp"
+#include "aa_device_spectrum_whitening.hpp"
 #include "aa_device_harmonic_summing.hpp"
 #include "aa_corner_turn.hpp"
 #include "aa_device_threshold.hpp"
@@ -799,6 +800,15 @@ namespace astroaccelerate {
     (*compute_time) = (*compute_time) + timer.Elapsed();
     //---------<
 	
+	//---------> Spectrum whitening
+	timer.Start();
+	cudaStream_t stream; stream = NULL;
+	spectrum_whitening_SGP1(d_frequency_power, (t_nTimesamples>>1), t_nDMs_per_batch, stream);
+	spectrum_whitening_SGP1(d_frequency_interbin, t_nTimesamples, t_nDMs_per_batch, stream);
+    timer.Stop();
+    printf("         -> Performing spectrum whitening took %f ms\n", timer.Elapsed());
+    (*compute_time) = (*compute_time) + timer.Elapsed();	
+	//---------<
     //-----------------------------------------------------------------------------------
     //if(i==0 && dm==0 && export_data) Export_data_in_range(d_half_C, nTimesamples/2, t_nDMs_per_batch, "power_data", dm_step[i], dm_low[i], tsamp, DM_shift);
     //-----------------------------------------------------------------------------------

--- a/src/aa_device_spectral_whitening.cu
+++ b/src/aa_device_spectral_whitening.cu
@@ -1,0 +1,26 @@
+#include <stdio.h>
+#include <cufft.h>
+#include "aa_params.hpp"
+#include "aa_device_spectrum_whitening_kernel.hpp"
+
+// define for debug info
+//#define POWER_DEBUG
+
+//{{{ Dopler Stretch 
+
+namespace astroaccelerate {
+
+	void spectrum_whitening_SGP1(float *d_input, unsigned long int nSamples, int nDMs, cudaStream_t &stream){
+		dim3 grid_size((nSamples + 128 - 1)/128, nDMs , 1);
+		dim3 block_size(128, 1, 1);
+		call_kernel_spectrum_whitening_SGP1(
+			block_size, 
+			grid_size, 
+			0, 
+			stream, 
+			d_input, 
+			nSamples
+		);
+	}
+
+} //namespace astroaccelerate

--- a/src/aa_device_spectral_whitening_kernel.cu
+++ b/src/aa_device_spectral_whitening_kernel.cu
@@ -1,0 +1,214 @@
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cufft.h>
+#include "aa_params.hpp"
+#include "aa_device_cuda_deprecated_wrappers.cuh"
+
+namespace astroaccelerate {
+
+__device__ __inline__ void Initiate(float *M, float *S, int *j, float element){
+	*M = element;
+	*S = 0;
+	*j = 1;
+}
+
+__device__ __inline__ void Add_one(float *M, float *S, int *j, float element){
+	float ftemp;
+	*j = (*j) + 1;
+	double r_j = (double) (*j);
+	*M = (*M) + element;
+	ftemp = ( r_j*element - (*M) );
+	*S = (*S) + 1.0f / ( r_j*( r_j - 1.0f ) )*ftemp*ftemp;
+}
+
+__device__ __inline__ void Merge(float *A_M, float *A_S, int *A_j, float B_M, float B_S, int B_j){
+	float ftemp;
+	double r_B_j = (double) B_j;
+	double r_A_j = (double) (*A_j);
+	
+	ftemp = ( r_B_j / r_A_j)*(*A_M) - B_M;
+	(*A_S) = (*A_S) + B_S + ( r_A_j/( r_B_j*(r_A_j + r_B_j) ) )*ftemp*ftemp;
+	(*A_M) = (*A_M) + B_M;
+	(*A_j) = (*A_j) + B_j;
+}
+
+__device__ __inline__ void Reduce_SM(float *M, float *S, int *j, float *s_par_MSD, int *s_par_nElements){
+	int jv;
+	
+	(*M)=s_par_MSD[threadIdx.x];
+	(*S)=s_par_MSD[blockDim.x + threadIdx.x];
+	(*j)=s_par_nElements[threadIdx.x];
+	
+	for (int i = ( blockDim.x >> 1 ); i > HALF_WARP; i = i >> 1) {
+		if (threadIdx.x < i) {
+			jv = s_par_nElements[i + threadIdx.x];
+			if( jv!=0){
+				if( (*j)==0 ){
+					(*M) = s_par_MSD[i + threadIdx.x];
+					(*S) = s_par_MSD[blockDim.x + i + threadIdx.x];
+					(*j) = jv;
+				}
+				else {
+					Merge(M, S, j, s_par_MSD[i + threadIdx.x], s_par_MSD[blockDim.x + i + threadIdx.x], jv);
+				}
+			}
+			
+			s_par_MSD[threadIdx.x] = (*M);
+			s_par_MSD[blockDim.x + threadIdx.x] = (*S);
+			s_par_nElements[threadIdx.x] = (*j);
+		}
+		__syncthreads();
+	}
+}
+
+__device__ __inline__ void Reduce_WARP(float *M, float *S, int *j){
+	float B_M, B_S;
+	int B_j;
+	
+	for (int q = HALF_WARP; q > 0; q = q >> 1) {
+		B_M = aa_shfl_down(AA_ASSUME_MASK, (*M), q);
+		B_S = aa_shfl_down(AA_ASSUME_MASK, (*S), q);
+		B_j = aa_shfl_down(AA_ASSUME_MASK, (*j), q);
+		
+		if(B_j>0){
+			if( (*j)==0 ) {
+				(*S) = B_S;
+				(*M) = B_M;
+				(*j) = B_j;
+			}
+			else {
+				Merge(M, S, j, B_M, B_S, B_j);
+			}
+		}
+	}
+}
+
+
+__device__ __inline__ void MSD_block(float *d_input, int *x_steps, unsigned long int *nSamples, float *s_par_MSD, int *s_par_nElements, float *mean, float *stdev){	
+	float M, S, ftemp;
+	int j;	
+
+	M=0; S=0; j=0;
+	int spos = threadIdx.x;
+	if( spos < (*nSamples) ){
+		ftemp = (float) d_input[spos];
+		Initiate( &M, &S, &j, ftemp);
+		
+		spos = spos + blockDim.x;
+		for (int xf = 1; xf < (*x_steps); xf++) {
+			if( spos < (*nSamples) ){
+				ftemp = (float) d_input[spos];
+				Add_one( &M, &S, &j, ftemp);
+				spos = spos + blockDim.x;
+			}
+		}
+	}
+	
+	s_par_MSD[threadIdx.x] = M;
+	s_par_MSD[128 + threadIdx.x] = S;
+	s_par_nElements[threadIdx.x] = j;
+	
+	__syncthreads();
+	
+	Reduce_SM( &M, &S, &j, s_par_MSD, s_par_nElements );
+	Reduce_WARP( &M, &S, &j);
+	
+	if(threadIdx.x == 0){
+		(*mean) = M / (double) j;
+		(*stdev) = sqrt(S / (double) j);
+		s_par_MSD[0] = (*mean);
+		s_par_MSD[1] = (*stdev);
+	}
+	
+	__syncthreads();
+	
+	(*mean) = s_par_MSD[0];
+	(*stdev) = s_par_MSD[1];
+	
+	__syncthreads();
+}
+
+
+__device__ __inline__ void MSD_block_outlier_rejection(float *d_input, int *x_steps, unsigned long int *nSamples, float *s_par_MSD, int *s_par_nElements, float *mean, float *stdev){	
+	float M, S, ftemp;
+	int j;
+	
+	float sigma = 3.0;
+	float limit_down = (*mean) - sigma*(*stdev);
+	float limit_up = (*mean) + sigma*(*stdev);
+
+	M=0;	S=0;	j=0;
+	int spos = threadIdx.x;
+	if( spos < (*nSamples) ){
+		for (int xf = 0; xf < (*x_steps); xf++) {
+			if( spos < (*nSamples) ){
+				ftemp = (float) d_input[spos];
+				if( (ftemp>limit_down) && (ftemp < limit_up) ){
+					if(j==0){
+						Initiate( &M, &S, &j, ftemp);
+					}
+					else{
+						Add_one( &M, &S, &j, ftemp);
+					}			
+				}
+				spos = spos + blockDim.x;
+			}
+		}	
+	}
+
+	s_par_MSD[threadIdx.x] = M;
+	s_par_MSD[blockDim.x + threadIdx.x] = S;
+	s_par_nElements[threadIdx.x] = j;
+	
+	__syncthreads();
+	
+	Reduce_SM( &M, &S, &j, s_par_MSD, s_par_nElements );
+	Reduce_WARP( &M, &S, &j);
+	
+	if(threadIdx.x == 0){
+		(*mean) = M / (double) j;
+		(*stdev) = sqrt(S / (double) j);
+		s_par_MSD[0] = (*mean);
+		s_par_MSD[1] = (*stdev);
+	}
+	
+	__syncthreads();
+	
+	(*mean) = s_par_MSD[0];
+	(*stdev) = s_par_MSD[1];
+	
+	__syncthreads();
+}
+
+
+__global__ void GPU_kernel_spectrum_whitening_SGP1(float *d_input, unsigned long int nSamples) {
+	__shared__ float s_par_MSD[256];
+	__shared__ int s_par_nElements[128];
+
+	float mean, stdev;
+	unsigned long int gpos = blockIdx.y*nSamples;
+	unsigned long int spos = blockIdx.x*blockDim.x;
+	int x_steps = 1;
+	
+	MSD_block(&d_input[gpos + spos], &x_steps, &nSamples, s_par_MSD, s_par_nElements, &mean, &stdev);
+	
+	MSD_block_outlier_rejection(&d_input[gpos + spos], &x_steps, &nSamples, s_par_MSD, s_par_nElements, &mean, &stdev);
+	
+	d_input[gpos + spos + threadIdx.x] = (d_input[gpos + spos + threadIdx.x] - mean)/stdev;
+}
+
+//---------------------------- WRAPPERS --------------------------
+
+void call_kernel_spectrum_whitening_SGP1(
+	const dim3 &block_size, 
+	const dim3 &grid_size, 
+	const int &smem_bytes, 
+	const cudaStream_t &stream, 
+	float *d_input, 
+	unsigned long int nSamples
+) {	
+	GPU_kernel_spectrum_whitening_SGP1<<< grid_size, block_size, smem_bytes, stream >>>(d_input, nSamples);
+}
+
+} //namespace astroaccelerate
+


### PR DESCRIPTION
---
name: Spectrum whitening
about: Spectrum whitening on the GPU added.
The algorithm used is the algorithm used in SIGPROC. The spectrum is divided into disjoint chunks of 128 samples. In each chunk, the mean and standard deviation is calculated with outlier rejection and then the chunk is normalized to mean zero and standard deviation of 1.

---

**Description of pull request**


**Interfaces**
Will this pull request result in a backwards-incompatible interface change: No

Expected semantic version number increment category (Please indicate x.y.z): y


**Issues this pull request solves**


**New tag of master**


**New deployment**


**Keep branch after merging** No


**Notes**
