### PR TITLE
fixed potential over and under flow in zerodm

### DIFF
--- a/include/aa_device_zero_dm_kernel.hpp
+++ b/include/aa_device_zero_dm_kernel.hpp
@@ -4,8 +4,15 @@
 namespace astroaccelerate {
 
   /** \brief Kernel wrapper function for zero_dm_kernel kernel function. */
-  void call_kernel_zero_dm_kernel(const dim3 &block_size, const dim3 &grid_size, const int &sharedMemory_size,
-				  unsigned short *const d_input, const int &nchans, const int &nsamp, const float &normalization_factor);
+  void call_kernel_zero_dm_kernel(
+    const dim3 &block_size, 
+    const dim3 &grid_size, 
+    const int &sharedMemory_size,
+    unsigned short *const d_input, 
+    const int &nchans, 
+    const int &nsamp, 
+    const int &nbits,
+    const float &normalization_factor);
 
 } // namespace astroaccelerate
   

--- a/include/aa_device_zero_dm_outliers_kernel.hpp
+++ b/include/aa_device_zero_dm_outliers_kernel.hpp
@@ -11,6 +11,7 @@ void call_kernel_zero_dm_outliers_kernel_channels(
 	unsigned short *const d_input, 
 	const int &nchans, 
 	const float &outlier_sigma, 
+	const int &nbits,
 	const float &normalization_factor);
 	
   /** \brief Kernel wrapper function for zero_dm_outliers_kernel_one kernel function. */

--- a/src/aa_zero_dm.cpp
+++ b/src/aa_zero_dm.cpp
@@ -21,7 +21,7 @@ namespace astroaccelerate {
     start_t = clock();
     
     float normalization_factor = ((pow(2,nbits)-1)/2);
-    call_kernel_zero_dm_kernel(num_blocks, threads_per_block, shared_memory, d_input, nchans, nsamp, normalization_factor);
+    call_kernel_zero_dm_kernel(num_blocks, threads_per_block, shared_memory, d_input, nchans, nsamp, nbits, normalization_factor);
     cudaDeviceSynchronize();
     
     end_t = clock();

--- a/src/aa_zero_dm_outliers.cpp
+++ b/src/aa_zero_dm_outliers.cpp
@@ -25,6 +25,7 @@ void zero_dm_outliers(unsigned short *const d_input, const int nchans, const int
 		d_input, 
 		nchans, 
 		outlier_sigma, 
+		nbits,
 		normalization_factor
 	); 
 }


### PR DESCRIPTION
fix of potential over and underflow in the zero DM

Problem is different bit precisions of the input. "nbits" was added as a kernel parameter to hep discriminate between cases and choose appropriate boundaries for numbers.

**Keep branch after merging**
No
