### PR TITLE
adding fopenmp flag to the generic Makefile; adding the GENCODE flag …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,14 +32,16 @@ GENCODE_SM60	:= -gencode arch=compute_60,code=sm_60 # Pascal
 GENCODE_SM61	:= -gencode arch=compute_61,code=sm_61 # Pascal
 GENCODE_SM70	:= -gencode arch=compute_70,code=sm_70 # Volta
 GENCODE_SM75    := -gencode arch=compute_75,code=sm_75 # Turing
-GENCODE_FLAGS   := $(GENCODE_SM61)
+GENCODE_SM80    := -gencode arch=compute_80,code=sm_80 # Ampere A100
+GENCODE_SM86    := -gencode arch=compute_86,code=sm_86 # Ampere RTX 30xx
+GENCODE_FLAGS   := $(GENCODE_SM86)
 
 ifeq ($(cache),off)
         NVCCFLAGS := $(INC) ${INCLUDE} -g -lineinfo -Xcompiler -O3 -lm --use_fast_math\
-        --ptxas-options=-v -Xptxas -dlcm=cg $(GENCODE_FLAGS)
+        --ptxas-options=-v -Xptxas -dlcm=cg $(GENCODE_FLAGS) -Xcompiler -fopenmp
 else
         NVCCFLAGS := $(INC) ${INCLUDE} -g -lineinfo -Xcompiler -O3 -lm --use_fast_math\
-        --ptxas-options=-v -lcuda -lcudart  -lcurand -lcufft -lcudadevrt -Xptxas -dlcm=cg $(GENCODE_FLAGS)
+        --ptxas-options=-v -lcuda -lcudart  -lcurand -lcufft -lcudadevrt -Xptxas -dlcm=cg $(GENCODE_FLAGS) -Xcompiler -fopenmp
 endif
 
 LIBJOBS := libastroaccelerate.a


### PR DESCRIPTION
---
name: Change of the default Makefile
about: solving issue #249 

---

**Description of pull request**
Improving the default Makefile to work with Ampere generation and adding an OPENMP compile flag

**Interfaces**
Will this pull request result in a backwards-incompatible interface change: no

Expected semantic version number increment category (Please indicate x.y.z): z


**Issues this pull request solves**
#249 

**New tag of master**
1.8.3

**New deployment**


**Keep branch after merging**
no

**Notes**
