### PR TITLE
adding cpu-msd, cache-dedisperse correction of overflow variables for…

### DIFF
--- a/include/aa_config.hpp
+++ b/include/aa_config.hpp
@@ -160,7 +160,7 @@ namespace astroaccelerate {
 					if (strcmp(string, "output_DDTR_normalization") == 0)
 						m_pipeline_options.insert(aa_pipeline::component_option::output_DDTR_normalization);
 					if (strcmp(string, "set_bandpass_average") == 0)
-						m_pipeline_options.insert(aa_pipeline::component_option::output_DDTR_normalization);
+						m_pipeline_options.insert(aa_pipeline::component_option::set_bandpass_average);
 					if (strcmp(string, "rfi") == 0)
 						flg.rfi = true;
 					if (strcmp(string, "oldrfi") == 0)

--- a/include/aa_host_cpu_msd.hpp
+++ b/include/aa_host_cpu_msd.hpp
@@ -1,0 +1,14 @@
+#ifndef ASTRO_ACCELERATE_AA_HOST_CPU_MSD_HPP
+#define ASTRO_ACCELERATE_AA_HOST_CPU_MSD_HPP
+
+#include <stdlib.h>
+
+namespace astroaccelerate {
+
+  /** \brief Performs mean and standard deviation on CPU. */
+  void call_cpu_msd(float* h_new_bandpass, unsigned short const*const input_buffer, size_t nchans, size_t nsamples);
+
+} // namespace astroaccelerate
+
+#endif // ASTRO_ACCELERATE_AA_HOST_CPU_MSD_HPP
+

--- a/include/aa_permitted_pipelines_generic.hpp
+++ b/include/aa_permitted_pipelines_generic.hpp
@@ -50,6 +50,7 @@
 
 #include "aa_gpu_timer.hpp"
 #include "aa_timelog.hpp"
+#include "aa_host_cpu_msd.hpp"
 
 namespace astroaccelerate {
 
@@ -507,6 +508,7 @@ namespace astroaccelerate {
 			}
 			
 			if(pipeline_error!=0) {
+				
 				memory_allocated = false;
 				return false;
 			}
@@ -519,15 +521,17 @@ namespace astroaccelerate {
 		bool input_data_preprocessing(){
 			cudaError_t cuda_error;
 			const aa_pipeline::component_option opt_set_bandpass_average = aa_pipeline::component_option::set_bandpass_average;
-			
 			if (m_pipeline_options.find(opt_set_bandpass_average) != m_pipeline_options.end()) {
-				LOG(log_level::debug, "Calculating zero DM bandpass (average)...");
+				LOG(log_level::debug, "Calculating zero DM bandpass (average)... ");
 				m_local_timer.Start();
 				
 				float *h_new_bandpass;
 				h_new_bandpass = new float[nchans];
+				size_t nsamples = m_ddtr_strategy.metadata().nsamples();
+
 				
 				// Place code here
+				call_cpu_msd(h_new_bandpass, m_input_buffer, (size_t)nchans, nsamples);
 				
 				cuda_error = cudaMemcpy(d_bandpass_normalization, h_new_bandpass, nchans*sizeof(float), cudaMemcpyHostToDevice);
 				if (cuda_error != cudaSuccess) {

--- a/src/aa_device_dedispersion_kernel.cu
+++ b/src/aa_device_dedispersion_kernel.cu
@@ -437,13 +437,13 @@ namespace astroaccelerate {
       // channel (c) at the current despersion measure (dm) 
       // ** dm is constant for this thread!!**
 
-      shift = ((size_t)(c*(i_nsamp)) + (size_t)t) + (size_t)(__float2int_rz (dm_shifts[c] * shift_temp));
+      shift = ((size_t)(c)*(size_t)(i_nsamp) + (size_t)(t)) + (size_t)(__float2int_rz (dm_shifts[c] * shift_temp));
 		
       local_kernel += (float)__ldg(&d_input[shift]);
     }
 
     // Write the accumulators to the output array. 
-    shift = ( ( (size_t)( blockIdx.y * SDIVINDM ) + (size_t)threadIdx.y ) * ( (size_t)i_t_processed_s ) ) + (size_t)t;
+    shift = ( ( (size_t)( blockIdx.y) * (size_t)(SDIVINDM ) + (size_t)threadIdx.y ) * ( (size_t)i_t_processed_s ) ) + (size_t)t;
 
     d_output[shift] = (local_kernel / i_nchans / bin);
 
@@ -453,27 +453,27 @@ namespace astroaccelerate {
 		size_t   shift;	
 		float local_kernel;
 
-		int t  = blockIdx.x * SDIVINT  + threadIdx.x;
+		size_t t  = blockIdx.x*SDIVINT + threadIdx.x;
 	
 		// Initialise the time accumulators
 		local_kernel = 0.0f;
 
-		float shift_temp = mstartdm + ((blockIdx.y * SDIVINDM + threadIdx.y) * mdmstep);
+		float shift_temp = mstartdm + ((blockIdx.y*SDIVINDM + threadIdx.y)*mdmstep);
 	
 		// Loop over the frequency channels.
 		for(int c = 0; c < i_nchans; c++) {
 			// Calculate the initial shift for this given frequency
 			// channel (c) at the current despersion measure (dm) 
 			// ** dm is constant for this thread!!**
-			shift = ((size_t)(c*(i_nsamp)) + (size_t)t) + (size_t)(__float2int_rz (d_dm_shifts[c]*shift_temp));
+			shift = (((size_t)(c)*(size_t)(i_nsamp)) + t) + (size_t)(__float2int_rz(d_dm_shifts[c]*shift_temp));
 			
 			local_kernel += (float)__ldg(&d_input[shift]);
 		}
 
 		// Write the accumulators to the output array. 
-		shift = ( (size_t)( ( blockIdx.y * SDIVINDM ) + threadIdx.y ) * ( (size_t)i_t_processed_s ) ) + (size_t)t;
+		shift = ((size_t)((blockIdx.y*SDIVINDM) + threadIdx.y)*((size_t)i_t_processed_s)) + t;
 
-		d_output[shift] = (local_kernel / i_nchans / bin);
+		d_output[shift] = (local_kernel/i_nchans/bin);
   }
  
 

--- a/src/aa_host_cpu_msd.cpp
+++ b/src/aa_host_cpu_msd.cpp
@@ -1,0 +1,40 @@
+#include "aa_host_cpu_msd.hpp"
+#include "aa_log.hpp"
+
+namespace astroaccelerate {
+
+//void textbook_msd_parallel(unsigned int first, unsigned int second, unsigned short* in_data, float* mean, double* sd, bool outlier_rejection, double old_mean, double old_stdev, double sigma){
+void textbook_msd_parallel(size_t first, size_t second, unsigned short const*const in_data, float* mean){
+        double sum = 0;
+        //double temp_sd = 0;
+        size_t nElements = 0;
+
+        //double low  = old_mean - sigma*old_stdev;
+        //double high = old_mean + sigma*old_stdev;
+
+        #pragma omp parallel for reduction (+: sum, nElements) // +:temp_sd
+        for(size_t i = 0; i < first; i++){
+                sum = 0.0;
+                //temp_sd = 0.0;
+                nElements = 0;
+                for(size_t j = 0; j < second; j++){
+//                        if (outlier_rejection && (in_data[i*second + j]<low || in_data[i*second + j]>high)){
+//                        } else {
+                                //temp_sd += in_data[i*second + j]*in_data[i*second + j];
+                                sum += in_data[i*second + j];
+                                nElements +=1;
+//                        }
+                }
+                mean[i] = sum/nElements;
+                //temp_sd = temp_sd - (sum*sum)/nElements;
+		if (i == 0) printf("\n\t %f %zu\n", mean[i], nElements);
+                //sd[i] = sqrt(temp_sd/nElements);
+        }
+}
+
+
+ void call_cpu_msd(float *h_new_bandpass, unsigned short const*const input_buffer, size_t nchans, size_t nsamples){
+	  LOG(log_level::debug, "Performing CPU MSD...");
+	  textbook_msd_parallel(nchans, nsamples, input_buffer, h_new_bandpass);
+ }
+} //namespace astroaccelerate


### PR DESCRIPTION
---
name: CPU mean computing for bandpass filter
about: Create a pull request to help us improve

---

**Description of pull request**
Adding the cpu computing of the mean for bandpass filter. Solving issue for cache dedispersion of overflow for cards with high gpu memory.

**Interfaces**
Will this pull request result in a backwards-incompatible interface change: no

Expected semantic version number increment category (Please indicate x.y.z): z

**Issues this pull request solves**


**New tag of master**


**New deployment**


**Keep branch after merging**
no

**Notes**
