### PR TITLE
Update of the periodicity search

### DIFF
--- a/cmake/py_astro_accelerate.py.in
+++ b/cmake/py_astro_accelerate.py.in
@@ -466,9 +466,9 @@ class aa_py_pipeline():
         return lib.aa_py_pipeline_api_bind_analysis_plan(self.m_obj, self.m_analysis_plan_ptr)
 
     def bind_periodicity_plan(self, plan: aa_py_periodicity_plan):
-        lib.aa_py_pipeline_api_bind_periodicity_plan.argtypes = [ctypes.c_void_p, ctypes.c_float, ctypes.c_float, ctypes.c_int, ctypes.c_int, ctypes.c_bool, ctypes.c_bool]
+        lib.aa_py_pipeline_api_bind_periodicity_plan.argtypes = [ctypes.c_void_p, ctypes.c_float, ctypes.c_bool, ctypes.c_float, ctypes.c_int, ctypes.c_int]
         lib.aa_py_pipeline_api_bind_periodicity_plan.restype = ctypes.c_bool
-        return lib.aa_py_pipeline_api_bind_periodicity_plan(self.m_obj, ctypes.c_float(plan.sigma_cutoff()), ctypes.c_float(plan.sigma_constant()), ctypes.c_int(plan.nHarmonics()), ctypes.c_int(plan.export_powers()), ctypes.c_bool(plan.candidate_algorithm()), ctypes.c_bool(plan.enable_msd_baseline_noise()))
+        return lib.aa_py_pipeline_api_bind_periodicity_plan(self.m_obj, ctypes.c_float(plan.sigma_cutoff()), ctypes.c_bool(plan.enable_msd_baseline_noise()), ctypes.c_float(plan.sigma_constant()), ctypes.c_int(plan.nHarmonics()), ctypes.c_int(plan.candidate_selection_algorithm()))
         
     def bind_fdas_plan(self, plan: aa_py_fdas_plan):
         lib.aa_py_pipeline_api_bind_fdas_plan.argtypes = [ctypes.c_void_p, ctypes.c_float, ctypes.c_float, ctypes.c_bool]

--- a/examples/src/fake_signal_periodic.cpp
+++ b/examples/src/fake_signal_periodic.cpp
@@ -17,6 +17,8 @@
 #include "aa_periodicity_plan.hpp"
 #include "aa_periodicity_strategy.hpp"
 
+#include <cufft.h>
+
 using namespace astroaccelerate;
 
 int main() {
@@ -64,15 +66,18 @@ int main() {
     return 0;
   }
 
-  const float periodicity_sigma_cutoff = 0.0;
-  const float periodicity_sigma_constant = sigma_constant;
-  const int   nHarmonics = 3;
-  const int   export_powers = 0;
-  const bool  candidate_algorithm = true;
-  const bool  enable_outlier_rejection = false;
+  const float periodicity_sigma_cutoff = 10.0;
+  const float periodicity_sigma_outlier_rejection_threshold = 3.0;
+  const int   nHarmonics = 32;
+  const int   candidate_algorithm = 0;
+  const bool  enable_outlier_rejection = true;
+  
+  size_t free = 0;
+  size_t total = 0;
+  cudaMemGetInfo(&free, &total);
 
-  aa_periodicity_plan periodicity_plan(periodicity_sigma_cutoff, periodicity_sigma_constant, nHarmonics, export_powers, candidate_algorithm, enable_outlier_rejection);
-  aa_periodicity_strategy periodicity_strategy(periodicity_plan);
+  aa_periodicity_plan periodicity_plan(strategy, periodicity_sigma_cutoff, enable_outlier_rejection, periodicity_sigma_outlier_rejection_threshold, nHarmonics, candidate_algorithm);
+  aa_periodicity_strategy periodicity_strategy(periodicity_plan, free);
 
   if(!periodicity_strategy.ready()) {
     std::cout << "ERROR: periodicity_strategy not ready." << std::endl;

--- a/examples/src/periodicity.cpp
+++ b/examples/src/periodicity.cpp
@@ -80,15 +80,18 @@ int main() {
     return 0;
   }
   
-  const float periodicity_sigma_cutoff = 0.0;
-  const float periodicity_sigma_constant = sigma_constant;
-  const int   nHarmonics = 3;
-  const int   export_powers = 0;
-  const bool  candidate_algorithm = false;
-  const bool  enable_outlier_rejection = false;
+  const float periodicity_sigma_cutoff = 10.0;
+  const float periodicity_sigma_outlier_rejection_threshold = 3.0;
+  const int   nHarmonics = 32;
+  const int   candidate_algorithm = 0;
+  const bool  enable_outlier_rejection = true;
   
-  aa_periodicity_plan periodicity_plan(periodicity_sigma_cutoff, periodicity_sigma_constant, nHarmonics, export_powers, candidate_algorithm, enable_outlier_rejection);
-  aa_periodicity_strategy periodicity_strategy(periodicity_plan);
+  size_t free = 0;
+  size_t total = 0;
+  cudaMemGetInfo(&free, &total);
+  
+  aa_periodicity_plan periodicity_plan(ddtr_strategy, periodicity_sigma_cutoff, enable_outlier_rejection, periodicity_sigma_outlier_rejection_threshold, nHarmonics, candidate_algorithm);
+  aa_periodicity_strategy periodicity_strategy(periodicity_plan, free);
 
   if(!periodicity_strategy.ready()) {
     std::cout << "ERROR: periodicity_strategy not ready." << std::endl;

--- a/include/aa_dedispersion_range.hpp
+++ b/include/aa_dedispersion_range.hpp
@@ -1,0 +1,101 @@
+#ifndef ASTRO_ACCELERATE_AA_DEDISPERSION_RANGE_HPP
+#define ASTRO_ACCELERATE_AA_DEDISPERSION_RANGE_HPP
+
+#include <iostream>
+#include <string>
+#include <stdio.h>
+
+#include "aa_log.hpp"
+
+
+namespace astroaccelerate {
+
+class aa_dedispersion_range {
+private:
+	double c_dm_low;         /** Lowest value of the dispersion measure in this dedispersion range [pc*cm-3] */
+	double c_dm_high;        /** Highest value of the dispersion measure in this dedispersion range [pc*cm-3] */
+	double c_dm_step;        /** Step in dispersion measure [pc*cm-3] */
+	double c_sampling_time;  /** Sampling time before binning [s] */
+	int    c_inBin;          /** Binning factor */
+	size_t c_nTimesamples;   /** Number of time-samples before binning */
+	size_t c_nDMs;           /** Number of DM-trials in this dedispersion range */
+
+public:
+	/** \brief Constructor for Dedispersion_Range. */
+	aa_dedispersion_range() {
+		c_dm_step = 0;
+		c_dm_low = 0;
+		c_dm_high = 0;
+		c_inBin = 0;
+		c_nTimesamples = 0;
+		c_nDMs = 0;
+		c_sampling_time = 0;
+	}
+
+	/** \brief Constructor for Dedispersion_Range. */
+	aa_dedispersion_range(
+		double dm_low, 
+		double dm_high, 
+		double dm_step, 
+		int inBin, 
+		size_t nTimesamples, 
+		size_t nDMs, 
+		double sampling_time
+	) {
+		c_dm_step = dm_step;
+		c_dm_low = dm_low;
+		c_dm_high = dm_high;
+		c_inBin = inBin;
+		c_nTimesamples = nTimesamples;
+		c_nDMs = nDMs;
+		c_sampling_time = sampling_time;
+	}
+
+	/** \brief Method to assign or change values of an instance after construction. */
+	void Assign(
+		double dm_low, 
+		double dm_high, 
+		double dm_step, 
+		int inBin, 
+		size_t nTimesamples, 
+		size_t nDMs, 
+		double sampling_time
+	) {
+		c_dm_step = dm_step;
+		c_dm_low = dm_low;
+		c_dm_high = dm_high;
+		c_inBin = inBin;
+		c_nTimesamples = nTimesamples;
+		c_nDMs = nDMs;
+		c_sampling_time = sampling_time;
+	}
+	
+	void print(){
+		LOG(log_level::debug, 
+		"  dedispersion range:" 
+		+ std::to_string(c_dm_low) 
+		+ "--" 
+		+ std::to_string(c_dm_high) 
+		+ ":" 
+		+ std::to_string(c_dm_step) 
+		+ "; Binning:" 
+		+ std::to_string(c_inBin) 
+		+ "; nTimesamples:" 
+		+ std::to_string(c_nTimesamples) 
+		+ "; nDMs:" 
+		+ std::to_string(c_nDMs) 
+		+ "; ts:" 
+		+ std::to_string(c_sampling_time));
+	}
+
+	double dm_low() {return(c_dm_low);}
+	double dm_high() {return(c_dm_high);}
+	double dm_step() {return(c_dm_step);}
+	double sampling_time() {return(c_sampling_time);}
+	int    inBin() {return(c_inBin);}
+	size_t nDMs() {return(c_nDMs);}
+	size_t nTimesamples() {return(c_nTimesamples);}
+};
+
+} // namespace astroaccelerate
+#endif // ASTRO_ACCELERATE_AA_DEDISPERSION_RANGE_HPP

--- a/include/aa_device_harmonic_summing.hpp
+++ b/include/aa_device_harmonic_summing.hpp
@@ -24,7 +24,7 @@ extern int periodicity_greedy_harmonic_summing(
   int enable_scalloping_loss_removal
 );
 
-extern int periodicity_presto_harmonic_summing(
+extern int periodicity_presto_plus_harmonic_summing(
   float *d_input,
   float *d_output_SNR,
   ushort *d_output_harmonics,

--- a/include/aa_device_harmonic_summing.hpp
+++ b/include/aa_device_harmonic_summing.hpp
@@ -3,9 +3,37 @@
 
 namespace astroaccelerate {
 
-extern void periodicity_simple_harmonic_summing_old(float *d_input, float *d_output_SNR, ushort *d_output_harmonics, float *d_MSD, int nTimesamples, int nSpectra, int nHarmonics);
+extern int periodicity_simple_harmonic_summing(
+  float *d_input,
+  float *d_output_SNR,
+  ushort *d_output_harmonics,
+  float *d_MSD,
+  int nTimesamples,
+  int nDMs,
+  int nHarmonics
+);
 
-extern void periodicity_simple_harmonic_summing(float *d_input, float *d_output_SNR, ushort *d_output_harmonics, float *d_MSD, int nTimesamples, int nSpectra, int nHarmonics);
+extern int periodicity_greedy_harmonic_summing(
+  float *d_input,
+  float *d_output_SNR,
+  ushort *d_output_harmonics,
+  float *d_MSD,
+  int nTimesamples,
+  int nDMs,
+  int nHarmonics,
+  int enable_scalloping_loss_removal
+);
+
+extern int periodicity_presto_harmonic_summing(
+  float *d_input,
+  float *d_output_SNR,
+  ushort *d_output_harmonics,
+  float *d_MSD,
+  int nTimesamples,
+  int nDMs,
+  int nHarmonics,
+  int enable_scalloping_loss_removal
+);
 
 } // namespace astroaccelerate
   

--- a/include/aa_device_harmonic_summing.hpp
+++ b/include/aa_device_harmonic_summing.hpp
@@ -35,6 +35,17 @@ extern int periodicity_presto_plus_harmonic_summing(
   int enable_scalloping_loss_removal
 );
 
+extern int periodicity_presto_harmonic_summing(
+  float *d_input,
+  float *d_output_SNR,
+  ushort *d_output_harmonics,
+  float *d_MSD,
+  int nTimesamples,
+  int nDMs,
+  int nHarmonics,
+  int enable_scalloping_loss_removal
+);
+
 } // namespace astroaccelerate
   
 #endif // ASTRO_ACCELERATE_AA_DEVICE_HARMONIC_SUMMING_HPP

--- a/include/aa_device_harmonic_summing_kernel.hpp
+++ b/include/aa_device_harmonic_summing_kernel.hpp
@@ -5,6 +5,7 @@ namespace astroaccelerate {
   class HRMS_ConstParams {
   public:
     static const int warp = 32;
+    static const int nThreads = 256;
   };
   
   class HRMS_normal : public HRMS_ConstParams {
@@ -53,6 +54,19 @@ namespace astroaccelerate {
       const int &nTimesamples,
       const int &nSpectra,
       const int &nHarmonics,
+      bool enable_scalloping_loss_removal
+  );
+  
+  void call_kernel_presto_harmonic_sum_GPU_kernel(
+      const dim3 &grid_size,
+      const dim3 &block_size,
+      float const *const d_input,
+      float *const d_output_SNR,
+      ushort *const d_output_harmonics,
+      float *const d_MSD,
+      const int &nTimesamples,
+      const int &nSpectra,
+      const int &nHarmonicsFactor,
       bool enable_scalloping_loss_removal
   );
 

--- a/include/aa_device_harmonic_summing_kernel.hpp
+++ b/include/aa_device_harmonic_summing_kernel.hpp
@@ -43,7 +43,7 @@ namespace astroaccelerate {
       bool enable_scalloping_loss_removal
   );
   
-  void call_kernel_presto_harmonic_sum_GPU_kernel(
+  void call_kernel_presto_plus_harmonic_sum_GPU_kernel(
       const dim3 &grid_size,
       const dim3 &block_size,
       float const *const d_input,

--- a/include/aa_device_harmonic_summing_kernel.hpp
+++ b/include/aa_device_harmonic_summing_kernel.hpp
@@ -2,14 +2,59 @@
 #define ASTRO_ACCELERATE_AA_DEVICE_HARMONIC_SUMMING_KERNEL_HPP
 
 namespace astroaccelerate {
-
-  /** \brief Kernel wrapper function for PHS_GPU_kernel_old kernel function. */
-void call_kernel_PHS_GPU_kernel_old(const dim3 &grid_size, const dim3 &block_size,
-					   float const *const d_input, float *const d_output_SNR, ushort *const d_output_harmonics, float *const d_MSD, const int &nTimesamples, const int &nSpectra, const int &nHarmonics);
+  class HRMS_ConstParams {
+  public:
+    static const int warp = 32;
+  };
+  
+  class HRMS_normal : public HRMS_ConstParams {
+  public:
+    static const bool remove_scalloping_loss = false;
+  };
+  
+  class HRMS_remove_scalloping_loss : public HRMS_ConstParams {
+  public:
+    static const bool remove_scalloping_loss = true;
+  };
 
   /** \brief Kernel wrapper function for PHS_GPU_kernel kernel function. */
-void call_kernel_PHS_GPU_kernel(const dim3 &grid_size, const dim3 &block_size,
-				       float const *const d_input, float *const d_output_SNR, ushort *const d_output_harmonics, float *const d_MSD, const int &nTimesamples, const int &nSpectra, const int &nHarmonics);
+  void call_kernel_simple_harmonic_sum_GPU_kernel(
+      const dim3 &grid_size,
+      const dim3 &block_size,
+      float const *const d_input,
+      float *const d_output_SNR,
+      ushort *const d_output_harmonics,
+      float *const d_MSD,
+      const int &nTimesamples,
+      const int &nSpectra,
+      const int &nHarmonics
+  );
+  
+  void call_kernel_greedy_harmonic_sum_GPU_kernel(
+      const dim3 &grid_size,
+      const dim3 &block_size,
+      float const *const d_input,
+      float *const d_output_SNR,
+      ushort *const d_output_harmonics,
+      float *const d_MSD,
+      const int &nTimesamples,
+      const int &nSpectra,
+      const int &nHarmonics,
+      bool enable_scalloping_loss_removal
+  );
+  
+  void call_kernel_presto_harmonic_sum_GPU_kernel(
+      const dim3 &grid_size,
+      const dim3 &block_size,
+      float const *const d_input,
+      float *const d_output_SNR,
+      ushort *const d_output_harmonics,
+      float *const d_MSD,
+      const int &nTimesamples,
+      const int &nSpectra,
+      const int &nHarmonics,
+      bool enable_scalloping_loss_removal
+  );
 
 } // namespace astroaccelerate
   

--- a/include/aa_device_peak_find.hpp
+++ b/include/aa_device_peak_find.hpp
@@ -16,9 +16,7 @@ namespace astroaccelerate {
 
   extern void PEAK_FIND_FOR_FDAS(float *d_ffdot_plane, float *d_peak_list, float *d_MSD, int nDMs, int nTimesamples, float threshold, unsigned int max_peak_size, unsigned int *gmem_peak_pos, float DM_trial);
 
-  extern void Peak_find_for_periodicity_search_old(float *d_input_SNR, ushort *d_input_harmonics, float *d_peak_list, int nDMs, int nTimesamples, float threshold, int max_peak_size, int *gmem_peak_pos, float *d_MSD, int DM_shift, int inBin);
-
-  extern void Peak_find_for_periodicity_search(float *d_input_SNR, ushort *d_input_harmonics, float *d_peak_list, int nDMs, int nTimesamples, float threshold, int max_peak_size, int *gmem_peak_pos, float* d_MSD, int DM_shift, int inBin);
+  extern int Peak_find_for_periodicity_search(float *d_input_SNR, ushort *d_input_harmonics, float *d_peak_list, int nDMs, int nTimesamples, float threshold, int max_peak_size, int *gmem_peak_pos, float* d_MSD, int DM_shift, int inBin, bool transposed_data);
 
   extern void SPDT_peak_find_stencil_7x7(float *d_output_SNR, ushort *d_output_taps, unsigned int *d_peak_list_DM, unsigned int *d_peak_list_TS, float *d_peak_list_SNR, unsigned int *d_peak_list_BW, int nDMs, int nTimesamples, float threshold, int max_peak_size, int *gmem_peak_pos, int shift, std::vector<PulseDetection_plan> *PD_plan, int max_iteration);
 

--- a/include/aa_device_peak_find_kernel.hpp
+++ b/include/aa_device_peak_find_kernel.hpp
@@ -19,20 +19,40 @@ namespace astroaccelerate {
 					     const unsigned int &max_peak_size, unsigned int *const gmem_pos, const float &DM_trial);
 
   /** \brief Kernel wrapper function for peak_find_for_periods_old kernel function. */
-  void call_kernel_dilate_peak_find_for_periods_old(const dim3 &grid_size, const dim3 &block_size,
-						    float *const d_input, ushort *const d_input_taps, float *const d_peak_list,
-						    const int &width, const int &height, const int &offset,
-						    const float &threshold,
-						    const int &max_peak_size, int *const gmem_pos, float *const d_MDF,
-						    const int &DM_shift, const int &DIT_value);
+  void call_kernel_peak_find_for_periodicity_normal(
+      const dim3 &grid_size,
+      const dim3 &block_size,
+      float *const d_input,
+      ushort *const d_input_taps,
+      float *const d_peak_list,
+      const int &nTimesamples,
+      const int &nDMs,
+      const int &offset,
+      const float &threshold,
+      const int &max_peak_size,
+      int *const gmem_pos,
+      float const *const d_MSD,
+      const int &DM_shift,
+      const int &DIT_value
+  );
 
   /** \brief Kernel wrapper function for peak_find_for_periods kernel function. */
-  void call_kernel_dilate_peak_find_for_periods(const dim3 &grid_size, const dim3 &block_size,
-						float *const d_input, ushort *const d_input_taps,
-						float *const d_peak_list, const int &width,
-						const int &height, const int &offset, const float &threshold,
-						const int &max_peak_size,
-						int *const gmem_pos, float const *const d_MSD, const int &DM_shift, const int &DIT_value);
+  void call_kernel_peak_find_for_periodicity_transposed(
+      const dim3 &grid_size,
+      const dim3 &block_size,
+      float *const d_input,
+      ushort *const d_input_taps,
+      float *const d_peak_list,
+      const int &width,
+      const int &height,
+      const int &offset,
+      const float &threshold,
+      const int &max_peak_size,
+      int *const gmem_pos,
+      float const *const d_MSD,
+      const int &DM_shift,
+      const int &DIT_value
+  );
 
   void call_kernel_peak_find_list(const dim3 &grid_size, const dim3 &block_size, float *const d_input, const int width, const int height, const float &threshold, int *const gmem_pos, const int &shift, const int &DIT_value, ushort *const d_input_taps, const int &max_peak_size, unsigned int *const d_peak_list_DM, unsigned int *const d_peak_list_TS, float *const d_peak_list_SNR, unsigned int *const d_peak_list_BW);
 

--- a/include/aa_device_periods.hpp
+++ b/include/aa_device_periods.hpp
@@ -1,9 +1,10 @@
 #ifndef ASTRO_ACCELERATE_AA_DEVICE_PERIODS_HPP
 #define ASTRO_ACCELERATE_AA_DEVICE_PERIODS_HPP
+#include "aa_periodicity_strategy.hpp"
 
 namespace astroaccelerate {
 
-extern void GPU_periodicity(int range, int processed, float sigma_cutoff, float ***output_buffer, int const*const ndms, int *inBin, float *dm_low, float *dm_high, float *dm_step, float tsamp, int nHarmonics, bool candidate_algorithm, bool enable_msd_baseline_noise, float bln_sigma_constant);
+extern void GPU_periodicity(aa_periodicity_strategy &PSR_strategy, float ***output_buffer);
 
 } // namespace astroaccelerate
   

--- a/include/aa_device_periods.hpp
+++ b/include/aa_device_periods.hpp
@@ -3,7 +3,7 @@
 
 namespace astroaccelerate {
 
-extern void GPU_periodicity(int range, int nsamp, int max_ndms, int processed, float sigma_cutoff, float ***output_buffer, int const*const ndms, int *inBin, float *dm_low, float *dm_high, float *dm_step, float tsamp, int nHarmonics, bool candidate_algorithm, bool enable_msd_baseline_noise, float bln_sigma_constant);
+extern void GPU_periodicity(int range, int processed, float sigma_cutoff, float ***output_buffer, int const*const ndms, int *inBin, float *dm_low, float *dm_high, float *dm_step, float tsamp, int nHarmonics, bool candidate_algorithm, bool enable_msd_baseline_noise, float bln_sigma_constant);
 
 } // namespace astroaccelerate
   

--- a/include/aa_device_periods.hpp
+++ b/include/aa_device_periods.hpp
@@ -1,10 +1,12 @@
 #ifndef ASTRO_ACCELERATE_AA_DEVICE_PERIODS_HPP
 #define ASTRO_ACCELERATE_AA_DEVICE_PERIODS_HPP
+
 #include "aa_periodicity_strategy.hpp"
+#include "aa_periodicity_candidates.hpp"
 
 namespace astroaccelerate {
 
-extern void GPU_periodicity(aa_periodicity_strategy &PSR_strategy, float ***output_buffer);
+extern void GPU_periodicity(aa_periodicity_strategy &PSR_strategy, float ***output_buffer, aa_periodicity_candidates &Power_Candidates, aa_periodicity_candidates &Interbin_Candidates);
 
 } // namespace astroaccelerate
   

--- a/include/aa_device_spectrum_whitening.hpp
+++ b/include/aa_device_spectrum_whitening.hpp
@@ -1,11 +1,17 @@
 #ifndef ASTRO_ACCELERATE_AA_DEVICE_SPECTRUM_WHITENING_HPP
 #define ASTRO_ACCELERATE_AA_DEVICE_SPECTRUM_WHITENING_HPP
 
+#include <stdio.h>
+#include <vector>
 #include <cufft.h>
 
 namespace astroaccelerate {
 
+extern void create_dered_segment_sizes_prefix_sum(std::vector<int> *segment_sizes, int min_segment_length, int max_segment_length, size_t nSamples);
+
 extern void spectrum_whitening_SGP1(float *d_input, unsigned long int nSamples, int nDMs, cudaStream_t &stream);
+
+extern void spectrum_whitening_SGP2(float2 *d_input, size_t nSamples, int nDMs, bool enable_median, cudaStream_t &stream);
 
 
 } // namespace astroaccelerate

--- a/include/aa_device_spectrum_whitening_kernel.hpp
+++ b/include/aa_device_spectrum_whitening_kernel.hpp
@@ -12,6 +12,42 @@ namespace astroaccelerate {
 		float *d_input, 
 		unsigned long int nSamples
 	);
+	
+	void call_kernel_segmented_MSD(
+		const  dim3 &block_size, 
+		const  dim3 &grid_size, 
+		const  int &smem_bytes, 
+		const  cudaStream_t &stream, 
+		float  *d_segmented_MSD, 
+		float2 *d_input, 
+		int    *d_segment_sizes,
+		size_t nSamples,
+		int    nSegments
+	);
+	
+	void call_kernel_segmented_median(
+		const  dim3 &block_size, 
+		const  dim3 &grid_size, 
+		const  int &smem_bytes, 
+		const  cudaStream_t &stream, 
+		float  *d_segmented_MSD, 
+		float2 *d_input, 
+		int    *d_segment_sizes,
+		size_t nSamples,
+		int    nSegments
+	);
+	
+	void call_kernel_spectrum_whitening_SGP2(
+		const  dim3 &block_size, 
+		const  dim3 &grid_size, 
+		const  int &smem_bytes, 
+		const  cudaStream_t &stream, 
+		float  *d_segmented_MSD, 
+		float2 *d_input,
+		int    *d_segment_sizes,
+		size_t nSamples,
+		int    nSegments
+	);
 
 } // namespace astroaccelerate
   

--- a/include/aa_device_threshold.hpp
+++ b/include/aa_device_threshold.hpp
@@ -9,9 +9,9 @@ namespace astroaccelerate {
   extern void THR_init(void);
   extern int SPDT_threshold(float *d_input, ushort *d_input_taps, unsigned int *d_output_list_DM, unsigned int *d_output_list_TS, float *d_output_list_SNR, unsigned int *d_output_list_BW, int *gmem_pos, float threshold, int nDMs, int nTimesamples, int shift, std::vector<PulseDetection_plan> *PD_plan, int max_iteration, int max_list_size);
 
-  extern int Threshold_for_periodicity_old(float *d_input, ushort *d_input_harms, float *d_output_list, int *gmem_pos, float *d_MSD, float threshold, int primary_size, int secondary_size, int DM_shift, int inBin, int max_list_size);
+  extern int Threshold_for_periodicity_transposed(float *d_input, ushort *d_input_harms, float *d_output_list,  int *gmem_pos, float *d_MSD, float threshold, int primary_size, int secondary_size, int DM_shift, int inBin, int max_list_size);
 
-  extern int Threshold_for_periodicity(float *d_input, ushort *d_input_harms, float *d_output_list, int *gmem_pos, float *d_MSD, float threshold, int primary_size, int secondary_size, int DM_shift, int inBin, int max_list_size);
+  extern int Threshold_for_periodicity_normal(float *d_input_SNR, ushort *d_input_harms, float *d_output_list,  int *gmem_pos, float *d_MSD, float threshold, int nTimesamples, int nDMs, int DM_shift, int inBin, int max_list_size);
 
 } // namespace astroaccelerate
   

--- a/include/aa_device_threshold_kernel.hpp
+++ b/include/aa_device_threshold_kernel.hpp
@@ -8,26 +8,57 @@
 namespace astroaccelerate {
 
   /** Kernel wrapper function for THR_GPU_WARP kernel function. */
-  void call_kernel_THR_GPU_WARP(const dim3 &grid_size, const dim3 &block_size,
-				float const *const d_input, ushort *const d_input_taps, unsigned int *const d_output_list_DM,
-				unsigned int *const d_output_list_TS, float *const d_output_list_SNR,
-				unsigned int *const d_output_list_BW, int *const gmem_pos,
-				const float &threshold, const int &nTimesamples, const int &offset, const int &shift, const int &max_list_size,
-				const int &DIT_value);
+  void call_kernel_THR_GPU_WARP(
+      const dim3 &grid_size,
+      const dim3 &block_size,
+      float const *const d_input,
+      ushort *const d_input_taps,
+      unsigned int *const d_output_list_DM,
+      unsigned int *const d_output_list_TS,
+      float *const d_output_list_SNR,
+      unsigned int *const d_output_list_BW,
+      int *const gmem_pos,
+      const float &threshold,
+      const int &nTimesamples,
+      const int &offset,
+      const int &shift,
+      const int &max_list_size,
+      const int &DIT_value
+  );
 
-  /** Kernel wrapper function for GPU_Threshold_for_periodicity_kernel_old kernel function. */
-  void call_kernel_GPU_Threshold_for_periodicity_kernel_old(const dim3 &grid_size, const dim3 &block_size,
-							    float const *const d_input, ushort *const d_input_harms,
-							    float *const d_output_list, int *const gmem_pos, float *const d_MSD,
-							    const float &threshold, const int &primary_size,
-							    const int &secondary_size, const int &DM_shift,
-							    const int &max_list_size, const int &DIT_value);
+  /** Kernel wrapper function for GPU_Threshold_for_periodicity_normal_kernel kernel function. */
+  void call_kernel_GPU_Threshold_for_periodicity_normal_kernel(
+      const dim3 &grid_size,
+      const dim3 &block_size,
+      float const *const d_input,
+      ushort *const d_input_harms,
+      float *const d_output_list,
+      int *const gmem_pos,
+      float const *const d_MSD,
+      const float &threshold,
+      const int &nTimesamples,
+      const int &nDMs,
+      const int &DM_shift,
+      const int &max_list_size,
+      const int &DIT_value
+  );
+
   /** Kernel wrapper function for GPU_Threshold_for_periodicity_kernel kernel function. */
-  void call_kernel_GPU_Threshold_for_periodicity_kernel(const dim3 &grid_size, const dim3 &block_size,
-							float const *const d_input, ushort *const d_input_harms,
-							float *const d_output_list, int *const gmem_pos, float const *const d_MSD,
-							const float &threshold, const int &primary_size, const int &secondary_size,
-							const int &DM_shift, const int &max_list_size, const int &DIT_value);
+  void call_kernel_GPU_Threshold_for_periodicity_transposed_kernel(
+      const dim3 &grid_size,
+      const dim3 &block_size,
+      float const *const d_input,
+      ushort *const d_input_harms,
+      float *const d_output_list,
+      int *const gmem_pos,
+      float const *const d_MSD,
+      const float &threshold,
+      const int &primary_size,
+      const int &secondary_size,
+      const int &DM_shift,
+      const int &max_list_size,
+      const int &DIT_value
+  );
 
 } // namespace astroaccelerate
 #endif // ASTRO_ACCELERATE_AA_DEVICE_THRESHOLD_KERNEL_HPP

--- a/include/aa_host_utilities.hpp
+++ b/include/aa_host_utilities.hpp
@@ -1,0 +1,30 @@
+#ifndef ASTRO_ACCELERATE_AA_HOST_UTILITIES_HPP
+#define ASTRO_ACCELERATE_AA_HOST_UTILITIES_HPP
+
+#include <iostream>
+#include <cufft.h>
+#include <stdio.h>
+
+namespace astroaccelerate {
+
+
+
+
+void MSD_Kahan(float *h_input, size_t nDMs, size_t nTimesamples, size_t offset, double *mean, double *sd);
+
+float Calculate_median(float *data, size_t primary_size);
+
+void Export_data_to_file(float2 *data, size_t primary_size, size_t secondary_size, const char *filename);
+
+void Export_data_to_file(float *data, size_t primary_size, size_t secondary_size, const char *filename);
+
+void Export_data_to_file(float2 *data1, float2 *data2, float2 *data3, size_t primary_size, const char *filename);
+
+void dered_with_MSD(float2 *data, int nSamples, int *segment_sizes, int nSegments, float *MSD);
+
+void dered_with_MED(float2 *data, int nSamples, int *segment_sizes, int nSegments, float *MED);
+
+
+} // namespace astroaccelerate
+
+#endif // ASTRO_ACCELERATE_AA_HOST_UTILITIES_HPP

--- a/include/aa_host_utilities.hpp
+++ b/include/aa_host_utilities.hpp
@@ -24,6 +24,8 @@ void dered_with_MSD(float2 *data, int nSamples, int *segment_sizes, int nSegment
 
 void dered_with_MED(float2 *data, int nSamples, int *segment_sizes, int nSegments, float *MED);
 
+void CPU_spectral_whitening(float* d_FFT_complex_output, float *d_dedispersed_data, float t_dm_step, float t_dm_low, size_t t_nTimesamples, size_t t_nTSamplesFFT, size_t t_nDMs_per_batch, size_t t_DM_shift);
+
 
 } // namespace astroaccelerate
 

--- a/include/aa_params.hpp
+++ b/include/aa_params.hpp
@@ -67,6 +67,7 @@ namespace astroaccelerate {
 
   // for periodicity harmonic summing
 #define PHS_NTHREADS 64
+#define GHRMS_NTHREADS 256
 
   // for power and interbin calculation
 #define PAI_NTHREADS 512

--- a/include/aa_params.hpp
+++ b/include/aa_params.hpp
@@ -67,7 +67,7 @@ namespace astroaccelerate {
 
   // for periodicity harmonic summing
 #define PHS_NTHREADS 64
-#define GHRMS_NTHREADS 256
+//#define GHRMS_NTHREADS 256
 
   // for power and interbin calculation
 #define PAI_NTHREADS 512

--- a/include/aa_periodicity_candidates.hpp
+++ b/include/aa_periodicity_candidates.hpp
@@ -1,0 +1,191 @@
+#ifndef ASTRO_ACCELERATE_AA_PERIODICITY_CANDIDATES_HPP
+#define ASTRO_ACCELERATE_AA_PERIODICITY_CANDIDATES_HPP
+#include <stdio.h>
+#include <string.h>
+
+
+namespace astroaccelerate {
+
+/**
+* \class aa_periodicity_candidates_data
+* \brief Class for AstroAccelerate to internally manage processing periodicity candidates.
+* \brief The user should not interact with this class for periodicity. 
+* \author -
+* \date -
+*/
+class aa_periodicity_candidates_data {
+private:
+	unsigned int *DM;  //index of the DM trial
+	unsigned int *t;   //index of the time sample in the DM trial
+	unsigned int *h;   //number of harmonics summed 
+	float        *SNR; //SNR value of the candidate
+	// temporary
+	float        *all;
+	int          c_nElements;
+	
+	size_t       c_nCandidates;
+	int          c_rangeid;
+	
+	void Allocate(){
+		all = (float*) malloc(c_nCandidates*c_nElements*sizeof(float));
+	}
+	
+	bool Copy_from_GPU(float *d_all){
+		if(all==NULL) return(false);
+		cudaError_t err = cudaMemcpy(all, d_all, c_nCandidates*c_nElements*sizeof(float), cudaMemcpyDeviceToHost);
+		if(err != cudaSuccess) return(false);
+		else return(true);
+	}
+	
+public:
+	aa_periodicity_candidates_data() {
+		DM  = NULL;
+		t   = NULL;
+		h   = NULL;
+		SNR = NULL;
+		all = NULL;
+		c_nElements = 4;
+		c_nCandidates = 0;
+		c_rangeid     = 0;
+	}
+	
+	//bool Add_candidates(unsigned int *d_DM, unsigned int *d_t, unsigned int *d_h, float *d_SNR, size_t nCandidates, int rangeid){
+	//	return(false);
+	//}
+	
+	bool Add_candidates(float *d_all, size_t nCandidates, int rangeid){
+		c_nCandidates = nCandidates;
+		c_rangeid     = rangeid;
+		c_nElements   = 4;
+		Allocate();
+		bool error = Copy_from_GPU(d_all);
+		return(error);
+	}
+	
+	size_t nCandidates(){
+		return(c_nCandidates);
+	}
+	
+	bool Copy_candidates_data(float *destination){
+		memcpy(destination, all, c_nCandidates*c_nElements*sizeof(float));
+		return(true);
+	}
+	
+	/** \brief Processes the periodicity inBin data group. */
+	void Process(float *MSD, double dm_low, double dm_step, double sampling_time, size_t nTimesamples, float mod) {
+		#pragma omp parallel for
+		for(size_t c = 0; c < c_nCandidates; c++) {
+			int harmonics = (int) all[c*c_nElements+3];
+			all[c*c_nElements+0] = all[c*c_nElements+0]*dm_step + dm_low;
+			all[c*c_nElements+1] = all[c*c_nElements+1]*(1.0/(sampling_time*nTimesamples*mod));
+			all[c*c_nElements+2] = (all[c*c_nElements+2] - MSD[2*harmonics])/(MSD[2*harmonics+1]);
+			all[c*c_nElements+3] = all[c*c_nElements+3];
+		}
+	}
+	
+	void Export_candidates_data_to_file(FILE *fp_out){
+		fwrite(all, c_nElements*sizeof(float), c_nCandidates, fp_out);
+	}
+	
+	~aa_periodicity_candidates_data(){
+		if(all != NULL) {
+			free(all);
+			all = NULL;
+		}
+	}
+};
+
+
+typedef aa_periodicity_candidates_data* PSR_candidate_data_pointer;
+
+/**
+ * \class aa_periodicity_candidates aa_periodicity_candidates.hpp "include/aa_periodicity_candidates.hpp"
+ * \brief Class that accumulates candidates from periodicity search.
+ * \author AstroAccelerate team.
+ */
+class aa_periodicity_candidates {
+private:
+	const size_t c_nElements = 4;
+	std::vector<PSR_candidate_data_pointer> candidate_data;
+	
+public:
+	aa_periodicity_candidates(){
+		
+	}
+	
+	bool Add_Candidates(float *d_all, size_t nCandidates, int rangeid, float *MSD, double dm_low, double dm_step, double sampling_time, size_t nTimesamples, float mod){
+		int last = 0;
+		bool passed = false;
+		candidate_data.push_back( (new aa_periodicity_candidates_data()) );
+		last = ((int) candidate_data.size()) - 1;
+		if(last >= 0){
+			passed = candidate_data[last]->Add_candidates(d_all, nCandidates, rangeid);
+			if(passed==true) {
+				candidate_data[last]->Process(MSD, dm_low, dm_step, sampling_time, nTimesamples, mod);
+				return(true);
+			}
+			else {
+				candidate_data[last]->~aa_periodicity_candidates_data();
+				return(false);
+			}
+		}
+		return(false);
+	}
+	
+	size_t nCandidates(){
+		int nLists = (int) candidate_data.size();
+		size_t nCandidates = 0;
+		for(int f = 0; f < nLists; f++){
+			nCandidates = nCandidates + candidate_data[f]->nCandidates();
+		}
+		return(nCandidates);
+	}
+	
+	bool Copy_candidates(float *list){
+		int nLists = (int) candidate_data.size();
+		std::vector<size_t> scan_candidates;
+		size_t temp_sum = 0;
+		scan_candidates.push_back(temp_sum);
+		for(int f = 0; f < nLists; f++){
+			temp_sum = temp_sum + candidate_data[f]->nCandidates();
+			scan_candidates.push_back(temp_sum);
+		}
+		
+		#pragma omp parallel for schedule(static, 1)
+		for(int f = 0; f < nLists; f++){
+			size_t pos = scan_candidates[f]*c_nElements;
+			candidate_data[f]->Copy_candidates_data(&list[pos]);
+		}
+		return(true);
+	}
+	
+	bool Export_candidates_to_file(const char *filename){
+		FILE *fp_out;
+		if((fp_out = fopen(filename, "wb")) == NULL) {
+			LOG(log_level::error, "Error opening output file!\n");
+		}
+		
+		int nLists = (int) candidate_data.size();
+		for(int f = 0; f < nLists; f++){
+			candidate_data[f]->Export_candidates_data_to_file(fp_out);
+		}
+		fclose(fp_out);
+		return(true);
+	}
+	
+	void Free_candidates(){
+		int nLists = (int) candidate_data.size();
+		for(int f = 0; f < nLists; f++){
+			candidate_data[f]->~aa_periodicity_candidates_data();
+		}
+		candidate_data.clear();
+	}
+	
+	~aa_periodicity_candidates(){
+		Free_candidates();
+	}
+};
+
+} // namespace astroaccelerate
+
+#endif // ASTRO_ACCELERATE_AA_PERIODICITY_STRATEGY_HPP

--- a/include/aa_periodicity_plan.hpp
+++ b/include/aa_periodicity_plan.hpp
@@ -2,83 +2,327 @@
 #define ASTRO_ACCELERATE_AA_PERIODICITY_PLAN_HPP
 
 #include <stdio.h>
+#include "aa_dedispersion_range.hpp"
+#include "aa_ddtr_strategy.hpp"
+
+#define PSR_HRMS_GREEDY 1
+#define PSR_HRMS_PRESTO_PLUS 2
+#define PSR_HRMS_PRESTO 3
 
 namespace astroaccelerate {
 
-  /**
-   * \class aa_periodicity_plan aa_periodicity_plan.hpp "include/aa_periodicity_plan.hpp"
-   * \brief Class to set a periodicity plan.
-   * \details A periodicity plan is required to create a periodicity strategy.
-   * \author Cees Carels.
-   * \date 23 October 2018.
-   */
+/**
+ * \class aa_periodicity_plan aa_periodicity_plan.hpp "include/aa_periodicity_plan.hpp"
+ * \brief Class to set a periodicity plan.
+ * \details A periodicity plan is required to create a periodicity strategy.
+ * \author AstroAccelerate team.
+ */
+class aa_periodicity_plan {
+public:
+	/** \brief Trivial constructor for aa_periodicity_plan. */
+	aa_periodicity_plan() {
+		c_sigma_cutoff = 10.0;
+		c_enable_outlier_rejection = true;
+		c_sigma_outlier_rejection_threshold = 3.0;
+		
+		c_nHarmonics = 32;
+		c_harmonic_sum_algorithm = 1;
+		
+		c_enable_interbinning = true;
+		c_enable_scalloping_loss_mitigation = true;
+		c_enable_spectrum_whitening = true;
+		c_pad_to_nearest_higher_pow2 = false;
+		
+		c_candidate_selection_algorithm = 0;
+	}
+	
+	/** \brief Constructor for aa_periodicity_plan that sets important member data on construction. */
+	aa_periodicity_plan(
+		const aa_ddtr_strategy &ddtr_strategy,
+		float t_sigma_cutoff,
+		bool t_enable_outlier_rejection,
+		float t_sigma_outlier_rejection_threshold,
+		int t_nHarmonics,
+		int t_candidate_selection_algorithm
+	) {
+		c_sigma_cutoff = t_sigma_cutoff;
+		c_enable_outlier_rejection = t_enable_outlier_rejection;
+		c_sigma_outlier_rejection_threshold = t_sigma_outlier_rejection_threshold;
+		c_nHarmonics = t_nHarmonics;
+		c_harmonic_sum_algorithm = 1;
+		c_candidate_selection_algorithm = t_candidate_selection_algorithm;
+		
+		c_enable_scalloping_loss_mitigation = true;
+		c_enable_interbinning = true;
+		c_enable_spectrum_whitening = true;
+		c_pad_to_nearest_higher_pow2 = false;
+		
+		Extract_data_from_ddtr_strategy(ddtr_strategy);
+	}
+	
+	/** \brief Constructor for aa_periodicity_plan that sets all member data on construction. */
+	aa_periodicity_plan(
+		const aa_ddtr_strategy &ddtr_strategy,
+		float t_sigma_cutoff,
+		bool t_enable_outlier_rejection,
+		float t_sigma_outlier_rejection_threshold,
+		int t_nHarmonics,
+		int t_harmonic_sum_algorithm,
+		int t_candidate_selection_algorithm,
+		bool t_enable_scalloping_loss_mitigation,
+		bool t_enable_interbinning,
+		bool t_enable_spectrum_whitening
+	) {
+		c_sigma_cutoff = t_sigma_cutoff;
+		c_enable_outlier_rejection = t_enable_outlier_rejection;
+		c_sigma_outlier_rejection_threshold = t_sigma_outlier_rejection_threshold;
+		c_nHarmonics = t_nHarmonics;
+		c_harmonic_sum_algorithm = t_harmonic_sum_algorithm;
+		c_candidate_selection_algorithm = t_candidate_selection_algorithm;
+		
+		c_enable_scalloping_loss_mitigation = t_enable_scalloping_loss_mitigation;
+		c_enable_interbinning = t_enable_interbinning;
+		c_enable_spectrum_whitening = t_enable_spectrum_whitening;
+		c_pad_to_nearest_higher_pow2 = false;
+		
+		Extract_data_from_ddtr_strategy(ddtr_strategy);
+	}
+	
+	/** \brief Constructor for aa_periodicity_plan that sets all member data on construction. */
+	aa_periodicity_plan(
+		float t_sigma_cutoff,
+		bool t_enable_outlier_rejection,
+		float t_sigma_outlier_rejection_threshold,
+		int t_nHarmonics,
+		int t_harmonic_sum_algorithm,
+		
+		bool t_enable_scalloping_loss_mitigation,
+		bool t_enable_interbinning,
+		
+		int t_candidate_selection_algorithm,
+		
+		size_t t_processed_time_samples,
+		double t_sampling_time,
+		int    t_nRanges,
+		float  *t_dm_low,
+		float  *t_dm_high,
+		float  *t_dm_step,
+		int    *t_inBin,
+		int const*const ndms
+	) {
+		c_sigma_cutoff = t_sigma_cutoff;
+		c_enable_outlier_rejection = t_enable_outlier_rejection;
+		c_sigma_outlier_rejection_threshold = t_sigma_outlier_rejection_threshold;
+		c_nHarmonics = t_nHarmonics;
+		c_harmonic_sum_algorithm = t_harmonic_sum_algorithm;
+		c_candidate_selection_algorithm = t_candidate_selection_algorithm;
+		
+		c_enable_scalloping_loss_mitigation = t_enable_scalloping_loss_mitigation;
+		c_enable_interbinning = t_enable_interbinning;
+		c_enable_spectrum_whitening = true;
+		c_pad_to_nearest_higher_pow2 = false;
+		
+		size_t c_nTimesamples = t_processed_time_samples;
+		double c_sampling_time = t_sampling_time;
+		printf("Creating plan from periodicity.\n");
+		printf("Number of total number of time samples: %zu;\n", c_nTimesamples);
+		printf("Sampling time: %e;\n", c_sampling_time);
+		int nRanges = t_nRanges;
+		for (int f = 0; f < nRanges; f++) {
+			double dm_low = (double) t_dm_low[f];
+			double dm_high = (double) t_dm_high[f];
+			double dm_step = (double) t_dm_step[f];
+			int inbin = t_inBin[f];
+			int nDMs = ndms[f];
+			aa_dedispersion_range newrange(dm_low, dm_high, dm_step, inbin, c_nTimesamples, nDMs, c_sampling_time);
+			printf("dm_low=%f; dm_high=%f; dm_step=%f; inbin=%d; nTimesamples=%zu; nDMs=%d; sampling_time=%e;\n", dm_low, dm_high, dm_step, inbin, c_nTimesamples, nDMs, c_sampling_time); 
+			ddtr_ranges.push_back(newrange);
+		}
+	}
 
-  class aa_periodicity_plan {
-  public:
+	//----------- Setters ------------>
+	void set_sigma_cutoff(float t_sigma_cutoff){
+		c_sigma_cutoff = t_sigma_cutoff;
+	}
+	
+	void set_sigma_outlier_rejection_threshold(float t_sigma_outlier_rejection_threshold){
+		c_sigma_outlier_rejection_threshold = t_sigma_outlier_rejection_threshold;
+	}
+	
+	void set_nHarmonics(int t_nHarmonics){
+		c_nHarmonics = t_nHarmonics;
+	}
+	
+	void set_outlier_rejection(bool t_switch){
+		c_enable_outlier_rejection = t_switch;
+	}
+	
+	void set_interbinning(bool t_switch){
+		c_enable_interbinning = t_switch;
+	}
+	
+	void set_scalloping_loss_mitigation(bool t_switch){
+		c_enable_scalloping_loss_mitigation = t_switch;
+	}
+	
+	void set_spectrum_whitening(bool t_switch){
+		c_enable_spectrum_whitening = t_switch;
+	}
+	
+	bool set_candidate_selection_algorithm(int algorithm_type){
+		if(algorithm_type==0) {
+			c_candidate_selection_algorithm = algorithm_type; // peak find
+			return(true);
+		}
+		if(algorithm_type==1) {
+			c_candidate_selection_algorithm = algorithm_type; // threshold
+			return(true);
+		}
+		if(algorithm_type==2) {
+			c_candidate_selection_algorithm = algorithm_type; // peak filtering
+			return(true);
+		}
+		c_candidate_selection_algorithm = 1;
+		return(false);
+	}
+	
+	bool set_harmonic_sum_algorithm(int algorithm_type){
+		if(algorithm_type==PSR_HRMS_GREEDY){
+			c_harmonic_sum_algorithm = PSR_HRMS_GREEDY;
+			return(true);
+		}
+		if(algorithm_type==PSR_HRMS_PRESTO_PLUS){
+			c_harmonic_sum_algorithm = PSR_HRMS_PRESTO_PLUS;
+			return(true);
+		}
+		if(algorithm_type==PSR_HRMS_PRESTO){
+			c_harmonic_sum_algorithm = PSR_HRMS_PRESTO;
+			return(true);
+		}
+		c_harmonic_sum_algorithm = PSR_HRMS_GREEDY;
+		return(false);
+	}
+	
+	//----------- Getters ------------>
+	float sigma_cutoff() {
+		return(c_sigma_cutoff);
+	}
+	
+	float sigma_outlier_rejection_threshold(){
+		return(c_sigma_outlier_rejection_threshold);
+	}
+	
+	int nHarmonics(){
+		return(c_nHarmonics);
+	}
+	
+	int harmonic_sum_algorithm(){
+		return(c_harmonic_sum_algorithm);
+	}
+	
+	int candidate_selection_algorithm(){
+		return(c_candidate_selection_algorithm);
+	}
+	
+	bool enable_outlier_rejection(){
+		return(c_enable_outlier_rejection);
+	}
+	
+	bool enable_interbinning(){
+		return(c_enable_interbinning);
+	}
+	
+	bool enable_scalloping_loss_mitigation(){
+		return(c_enable_scalloping_loss_mitigation);
+	}
+	
+	bool enable_spectrum_whitening(){
+		return(c_enable_spectrum_whitening);
+	}
+	
+	bool pad_to_nearest_higher_pow2(){
+		return(c_pad_to_nearest_higher_pow2);
+	}
+	
+	size_t nRanges() const {
+		return(ddtr_ranges.size());
+	}
+	
+	aa_dedispersion_range get_range(size_t id) const {
+		return(ddtr_ranges.at(id));
+	}
+	
+	std::vector<aa_dedispersion_range> get_all_ranges(){
+		return ddtr_ranges;
+	}
+	
+	double sampling_time(){
+		return(c_sampling_time);
+	}
+	
+	void print(){
+		printf("sigma_cutoff = %f;\n", c_sigma_cutoff);
+		printf("sigma_outlier_rejection_threshold = %f;\n", c_sigma_outlier_rejection_threshold);
+		printf("nHarmonics = %d;\n", c_nHarmonics);
+		if(c_harmonic_sum_algorithm==0) printf("harmonic sum algorithm = simple;\n");
+		else if(c_harmonic_sum_algorithm==1) printf("harmonic sum algorithm = greedy;\n");
+		else if(c_harmonic_sum_algorithm==2) printf("harmonic sum algorithm = presto;\n");
+		printf("candidate_selection_algorithm = %d;\n", c_candidate_selection_algorithm);
+		printf("enable_outlier_rejection = "); if(c_enable_outlier_rejection) printf("true;\n"); else printf("false;\n");
+		printf("enable_interbinning = "); if(c_enable_interbinning) printf("true;\n"); else printf("false;\n");
+		printf("enable_scalloping_loss_mitigation = "); if(c_enable_scalloping_loss_mitigation) printf("true;\n"); else printf("false;\n");
+		printf("enable_spectrum_whitening = "); if(c_enable_spectrum_whitening) printf("true;\n"); else printf("false;\n");
+		printf("pad_to_nearest_higher_pow2 = "); if(c_pad_to_nearest_higher_pow2) printf("true;\n"); else printf("false;\n");
+	}
+	
+	//------------------------- PRIVATE ------------------------------------
+private:
+	float c_sigma_cutoff;                      /** User selected value of sigma cutoff. Any event with SNR below this value will not be selected as candidate */
+	float c_sigma_outlier_rejection_threshold; /** User selected sigma for outlier rejection. Any value with sigma greater than this will be rejected. */
+	int   c_nHarmonics;                        /** User selected number of harmonics performed by the periodicity search. */
+	int   c_harmonic_sum_algorithm;            /** Flag for selection of the harmonic sum algorithm */
+	int   c_candidate_selection_algorithm;     /** User selected flag to select reduction algorithm to select candidates. */
+	bool  c_enable_outlier_rejection;          /** User selected flag to enable or disable outlier rejection when calculating mean and standard deviation. */
+	bool  c_enable_interbinning;               /** Enable or disable interpolation for periodicity search */
+	bool  c_enable_scalloping_loss_mitigation; /** Enable 5-point convolution which mitigates scalloping loss */
+	bool  c_enable_spectrum_whitening;         /** Enable or disable spectrum whitening (removal of the red noise) for periodicity search */
+	bool  c_pad_to_nearest_higher_pow2;        /** Whether the periodicity will pad data to the nearest power of two for the Fourier transform. True by default */
 
-    /** \brief Trivial constructor for aa_periodicity_plan. */
-    aa_periodicity_plan() : m_sigma_cutoff(0),
-			    m_sigma_constant(0),
-			    m_nHarmonics(0),
-			    m_export_powers(0),
-			    m_candidate_algorithm(false),
-			    m_enable_msd_baseline_noise(false) {
-      
-    }
-    
-    /** \brief Constructor for aa_periodicity_plan that sets all member data on construction. */
-    aa_periodicity_plan(const float &sigma_cutoff,
-			const float &sigma_constant,
-			const int   &nHarmonics,
-			const int   &export_powers,
-			const bool  &candidate_algorithm,
-			const bool  &enable_msd_baseline_noise) : m_sigma_cutoff(sigma_cutoff),
-								  m_sigma_constant(sigma_constant),
-								  m_nHarmonics(nHarmonics),
-								  m_export_powers(export_powers),
-								  m_candidate_algorithm(candidate_algorithm),
-								  m_enable_msd_baseline_noise(enable_msd_baseline_noise) {
-      
-    }
-    
-    /** \returns User selected sigma_cutoff. */
-    float sigma_cutoff() const {
-      return m_sigma_cutoff;
-    }
+	std::vector<aa_dedispersion_range> ddtr_ranges; /** DDTR - plan as calculated by ddtr strategy. */
+	size_t c_nTimesamples;
+	double c_sampling_time;
+	
+	void Extract_data_from_ddtr_strategy(const aa_ddtr_strategy &ddtr_strategy){
+		//-------- Extraction from ddtr_strategy
+		c_nTimesamples = 0;
+		int nTimechunks = ddtr_strategy.num_tchunks();
+		const std::vector<std::vector<int>> processed_samples = ddtr_strategy.t_processed();
+		for(int f = 0; f < nTimechunks; f++){
+			c_nTimesamples = c_nTimesamples + processed_samples[0][f];
+		}
+		printf("Extracting data from ddtr_strategy!\n");
+		printf("Number of total number of time samples: %zu;\n", c_nTimesamples);
+		
+		aa_filterbank_metadata temp_metadata;
+		temp_metadata = ddtr_strategy.metadata();
+		double c_sampling_time = temp_metadata.tsamp();
+		printf("Sampling time: %e;\n", c_sampling_time);
+		
+		int nRanges = ddtr_strategy.ndms_size();
+		for (int f = 0; f < nRanges; f++) {
+			aa_ddtr_plan::dm DM_range = ddtr_strategy.dm(f);
+			double dm_low = (double) DM_range.low;
+			double dm_high = (double) DM_range.high;
+			double dm_step = (double) DM_range.step;
+			int inbin = DM_range.inBin;
+			int nDMs = ddtr_strategy.ndms(f);
+			aa_dedispersion_range newrange(dm_low, dm_high, dm_step, inbin, c_nTimesamples, nDMs, c_sampling_time);
+			printf("dm_low=%f; dm_high=%f; dm_step=%f; inbin=%d; nTimesamples=%zu; nDMs=%d; sampling_time=%e;\n", dm_low, dm_high, dm_step, inbin, c_nTimesamples, nDMs, c_sampling_time); 
+			ddtr_ranges.push_back(newrange);
+		}
+	}
 
-    /** \returns User selected sigma_constant. */
-    float sigma_constant() const {
-      return m_sigma_constant;
-    }
-
-    /** \returns User selected nHarmonics. */
-    int nHarmonics() const {
-      return m_nHarmonics;
-    }
-
-    /** \returns User selected export_powers. */
-    int export_powers() const {
-      return m_export_powers;
-    }
-
-    /** \returns A boolean flag to indicate whether the candidate algorithm was selected. True indicates that it is, false indicates that it is not. */
-    bool candidate_algorithm() const {
-      return m_candidate_algorithm;
-    }
-    
-    /** \returns A boolean indicating whether the msd_baseline_noise algorithm will be enabled, for an instance of aa_periodicity_strategy. */
-    bool enable_msd_baseline_noise() const {
-      return m_enable_msd_baseline_noise;
-    }
-    
-  private:
-    float m_sigma_cutoff; /** User selected sigma_cutoff. */
-    float m_sigma_constant; /** User selected sigma_constant. */
-    int   m_nHarmonics; /** User selected nHarmonics. */
-    int   m_export_powers; /** User selected export_powers. */
-    bool  m_candidate_algorithm; /** User selected flag to enable or disable the use of the candidate_algorithm. */
-    bool  m_enable_msd_baseline_noise; /** User selected flag to enable or disable msd baseline noise. */
-  };
+};
 } // namespace astroaccelerate
 
 #endif // ASTRO_ACCELERATE_AA_PERIODICITY_PLAN_HPP

--- a/include/aa_periodicity_strategy.hpp
+++ b/include/aa_periodicity_strategy.hpp
@@ -2,133 +2,520 @@
 #define ASTRO_ACCELERATE_AA_PERIODICITY_STRATEGY_HPP
 
 #include <stdio.h>
+//#include <cufft.h>
 
 #include "aa_strategy.hpp"
 #include "aa_periodicity_plan.hpp"
+#include "aa_dedispersion_range.hpp"
+//#include "aa_periodicity_processing_chunks.hpp"
 #include "aa_log.hpp"
+#include "aa_params.hpp"
+#include "aa_device_MSD_Configuration.hpp"
+//#include "aa_device_MSD_plane_profile.hpp"
 
 namespace astroaccelerate {
 
-  /**
-   * \class aa_periodicity_strategy aa_periodicity_strategy.hpp "include/aa_periodicity_strategy.hpp"
-   * \brief Class that receives an aa_periodicity_plan object, and produces an aa_periodicity_strategy object.
-   * \details A periodicity strategy is required for any pipeline running the periodicity component.
-   * \author Cees Carels.
-   * \date 23 October 2018.
-   */
-  
-  class aa_periodicity_strategy : public aa_strategy {
-  public:
+/**
+* \class aa_periodicity_batch
+* \brief Class for AstroAccelerate to manage processing periodicity data.
+* \brief The user should not interact with this class for periodicity. Instead, the user should use aa_periodicity_plan and aa_periodicity_strategy.
+* \author -
+* \date -
+*/
+class aa_periodicity_batch {
+public:
+	size_t nDMs_per_batch;
+	size_t nTimesamples;
+	size_t DM_shift;
+	MSD_Configuration MSD_conf;
 
-    /** \brief Trivial constructor for aa_periodicity_strategy, which can never have a ready state equal to true. */
-    aa_periodicity_strategy() : m_sigma_cutoff(0),
-				m_sigma_constant(0),
-				m_nHarmonics(0),
-				m_export_powers(0),
-				m_candidate_algorithm(false),
-				m_enable_msd_baseline_noise(false),
-				m_ready(false) {
-      
-    }
-    
-    /** \brief Constructor for aa_periodicity_strategy that sets all member variables upon construction. */
-    aa_periodicity_strategy(const aa_periodicity_plan &plan) : m_sigma_cutoff(plan.sigma_cutoff()),
-							       m_sigma_constant(plan.sigma_constant()),
-							       m_nHarmonics(plan.nHarmonics()),
-							       m_export_powers(plan.export_powers()),
-							       m_candidate_algorithm(plan.candidate_algorithm()),
-							       m_enable_msd_baseline_noise(plan.enable_msd_baseline_noise()),
-							       m_ready(false) {
-      /** Parse user input, if the user input is not valid, then the ready state will not become true. */
-      if((m_nHarmonics > 0) && (m_sigma_constant > 0) && (m_export_powers >= 0)) {
-	m_ready = true;
-      }
-      else {
-	LOG(log_level::warning, "Invalid periodicity strategy parameters. Check the aa_periodicity_plan input parameters.");
-	print_info(*this);
-      }
-    }
+	/** \brief Constructor for aa_periodicity_batch. */
+	aa_periodicity_batch(size_t t_nDMs_per_batch, size_t t_DM_shift, size_t t_nTimesamples, int total_blocks) {
+		nDMs_per_batch = t_nDMs_per_batch;
+		nTimesamples   = t_nTimesamples;
+		DM_shift       = t_DM_shift;
+		
+		// We divide nTimesamples by 2 because MSD is determined from power spectra (or because of FFT R->C)
+		MSD_conf = *(new MSD_Configuration((nTimesamples>>1) + 1, nDMs_per_batch, 0, total_blocks));
+	}
 
-    /** \returns The name of the module. */
-    std::string name() const {
-      return "periodicity_strategy";
-    }
-    
-    /** \returns The strategy determined sigma_cutoff. */
-    float sigma_cutoff() const {
-      return m_sigma_cutoff;
-    }
+	/** \brief Destructor for aa_periodicity_batch. */
+	~aa_periodicity_batch() {
+		//delete MSD_conf;
+	}
+	
+	/** \brief Method for printing member variable data for an instance. */
+	void print(int id) {
+		LOG(log_level::debug, "    Batch:" + std::to_string(id) + "; nDMs:" + std::to_string(nDMs_per_batch) + "; nTimesamples:" + std::to_string(nTimesamples) + "; DM shift:" + std::to_string(DM_shift) + ";");
+	}
+};
 
-    /** \returns The strategy determined sigma_constant. */
-    float sigma_constant() const {
-      return m_sigma_constant;
-    }
+/**
+* \class aa_periodicity_range
+* \brief Class for AstroAccelerate to manage periodicity ranges.
+* \brief The user should not use this class for interacting with periodicity. Instead, the user should use aa_periodicity_plan and aa_periodicity_strategy.
+* \author -
+* \date -
+*/
+class aa_periodicity_range {
+public:
+	aa_dedispersion_range range;
+	int rangeid;
+	std::vector<aa_periodicity_batch> batches;
+	size_t total_MSD_blocks;
 
-    /** \returns The strategy determined nHarmonics. */
-    int nHarmonics() const {
-      return m_nHarmonics;
-    }
+	void Create_Batches(size_t max_nDMs_in_range) {
+		int nRepeats, nRest;
+		total_MSD_blocks = 0;
+		
+		nRepeats = range.nDMs()/max_nDMs_in_range;
+		nRest    = range.nDMs() - nRepeats*max_nDMs_in_range;
+		for(int f=0; f<nRepeats; f++) {
+			aa_periodicity_batch batch(max_nDMs_in_range, f*max_nDMs_in_range, range.nTimesamples(), 0);
+			batches.push_back(batch);
+			if((size_t) batch.MSD_conf.nBlocks_total > total_MSD_blocks) total_MSD_blocks = batch.MSD_conf.nBlocks_total;
+		}
+		if(nRest>0) {
+			aa_periodicity_batch batch(nRest, nRepeats*max_nDMs_in_range, range.nTimesamples(), 0);
+			batches.push_back(batch);
+			if((size_t) batch.MSD_conf.nBlocks_total > total_MSD_blocks) total_MSD_blocks = batch.MSD_conf.nBlocks_total;
+		}
+	}
 
-    /** \returns The strategy determined export_powers. */
-    int export_powers() const {
-      return m_export_powers;
-    }
+	aa_periodicity_range(aa_dedispersion_range t_range, size_t corrected_c_max_nTimesamples, size_t max_nDMs_in_memory, int t_rangeid) {
+		double dm_low        = t_range.dm_low();
+		double dm_high       = t_range.dm_high();
+		double dm_step       = t_range.dm_step();
+		int    inBin         = t_range.inBin();
+		size_t nTimesamples  = t_range.nTimesamples(); 
+		size_t nDMs          = t_range.nDMs(); 
+		double sampling_time = t_range.sampling_time();
+		
+		nTimesamples  = corrected_c_max_nTimesamples/inBin;
+		sampling_time = sampling_time*inBin;
+		range.Assign(dm_low, dm_high, dm_step, inBin, nTimesamples, nDMs, sampling_time);
+		
+		size_t max_nDMs_in_range = max_nDMs_in_memory*inBin;
+		rangeid = t_rangeid;
+		Create_Batches(max_nDMs_in_range);
+	}
 
-    /** \returns The strategy determined candidate algorithm flag. */
-    bool candidate_algorithm() const {
-      return m_candidate_algorithm;
-    }
-  
-    /** \returns an integer to indicate whether the msd baseline noise reduction algorithm will be enabled or disabled. 0 for off (false), 1 for on (true). */
-    int enable_msd_baseline_noise() const {
-      return (m_enable_msd_baseline_noise) ? 1 : 0;
-    }
-    
-    /** \returns The ready state of the instance of the class. */
-    bool ready() const {
-      return m_ready;
-    }
-    
-    /** \brief Performs any remaining setup needed. 
-     * \returns Whether the operation was successful or not, at the moment this is the ready state of the instance. */
-    bool setup() {
-      return ready();
-    }
+	/** \brief Destructor for aa_periodicity_range. */
+	~aa_periodicity_range() {
+		batches.clear();
+	}
 
-    /** \brief Print the member data of the instnace.
-     * \returns A boolean flag to indicate whether the operation completed successfully (true) or unsuccessfully (false). */
-    bool print_parameters() const {
-      printf("Periodicity - sigma_cutoff %f\n", m_sigma_cutoff);
-      printf("Periodicity - sigma_constant %f\n", m_sigma_constant);
-      printf("Periodicity - nHarmonics %d\n", m_nHarmonics);
-      printf("Periodicity - export_powers %d\n", m_export_powers);
-      printf("Periodicity - candidate_algorithm %d\n", m_candidate_algorithm);
-      printf("Periodicity - enable_msd_baseline_noise %d\n", m_enable_msd_baseline_noise);
-      return true;
-    }
+	/** \brief Method for printing member variable data of an instance. */
+	void print(void) {
+		int size = (int)batches.size();
+		int batchDM_0 = batches[0].nDMs_per_batch;
+		
+		range.print();
+		
+		if(size>1) {
+			int batchDM_last = batches[size-1].nDMs_per_batch;
+			LOG(log_level::debug, "  Periodicity search will run " + std::to_string(size) + " batches each containing " + std::to_string(batchDM_0) + " DM trials with tail of " + std::to_string(batchDM_last) + " DM trials");
+		}
+		else {
+			LOG(log_level::debug, "  Periodicity search will run 1 batch containing " + std::to_string(batchDM_0) + " DM trials.");
+		}
+		
+		float MSD_block_mem = (total_MSD_blocks*MSD_PARTIAL_SIZE*sizeof(float))/(1024.0*1024.0);
+		LOG(log_level::debug, "  Total number of MSD blocks is " + std::to_string(total_MSD_blocks) + " which is " + std::to_string(MSD_block_mem) + "MB");
+		//#ifdef GPU_PERIODICITY_SEARCH_DEBUG
+			LOG(log_level::debug, "  > Batches:");
+			for(int f=0; f<(int)batches.size(); f++) batches[f].print(f);
+		//#endif
+	}
+};
 
-    /** Static member function that prints member variables for a provided aa_periodicity_strategy. */
-    static bool print_info(const aa_periodicity_strategy &strategy) {
-      LOG(log_level::dev_debug, "PERIODICITY STRATEGY INFORMATION:");
-      LOG(log_level::dev_debug, "periodicity sigma_cutoff:\t\t" + std::to_string(strategy.sigma_cutoff()));
-      LOG(log_level::dev_debug, "periodicity sigma_constant:\t\t" + std::to_string(strategy.sigma_constant()));
-      LOG(log_level::dev_debug, "periodicity nHarmonics:\t\t\t" + std::to_string(strategy.nHarmonics()));
-      LOG(log_level::dev_debug, "periodicity export_powers:\t\t" + std::to_string(strategy.export_powers()));
-      LOG(log_level::dev_debug, "periodicity candidate_algorithm:\t\t" + (strategy.candidate_algorithm() ? std::string("true") : std::string("false")));
-      LOG(log_level::dev_debug, "periodicity enable_msd_baseline_noise:\t" + (strategy.enable_msd_baseline_noise() ? std::string("true") : std::string("false")));
-      return true;
-    }
-    
-  private:
-    float m_sigma_cutoff; /** Strategy determined sigma_cutoff. */
-    float m_sigma_constant; /** Strategy determined sigma_constant. */
-    int   m_nHarmonics; /** Strategy determined nHarmonics. */
-    int   m_export_powers; /** Strategy determined export_powers. */
-    bool  m_candidate_algorithm; /** Strategy determined candidate algorithm flag. */
-    bool  m_enable_msd_baseline_noise; /** Strategy determined msd baseline noise flag. */
 
-    bool m_ready; /** Ready state of the instance. */
-  };
+typedef aa_periodicity_range* p_range_pointer;
+
+/**
+ * \class aa_periodicity_strategy aa_periodicity_strategy.hpp "include/aa_periodicity_strategy.hpp"
+ * \brief Class that receives an aa_periodicity_plan object, and produces an aa_periodicity_strategy object.
+ * \details A periodicity strategy is required for any pipeline running the periodicity component.
+ * \author AstroAccelerate team.
+ * \date 23 October 2018.
+ */
+class aa_periodicity_strategy : public aa_strategy {
+private:
+	// User configured values;
+	float c_sigma_cutoff;                      /** User selected value of sigma cutoff. Any event with SNR below this value will not be selected as candidate */
+	float c_sigma_outlier_rejection_threshold; /** User selected sigma for outlier rejection. Any value with sigma greater than this will be rejected. */
+	int   c_nHarmonics;                        /** User selected number of harmonics performed by the periodicity search. */
+	int   c_harmonic_sum_algorithm;            /** Flag for selection of the harmonic sum algorithm */
+	int   c_candidate_selection_algorithm;               /** User selected flag to select reduction algorithm to select candidates. */
+	bool  c_enable_outlier_rejection;          /** User selected flag to enable or disable outlier rejection when calculating mean and standard deviation. */
+	bool  c_enable_interbinning;              /** Enable or disable interpolation for periodicity search */
+	bool  c_enable_scalloping_loss_mitigation; /** Enable 5-point convolution which mitigates scalloping loss */
+	bool  c_enable_spectrum_whitening;         /** Enable or disable spectrum whitening (removal of the red noise) for periodicity search */
+	bool  c_pad_to_nearest_higher_pow2;        /** Whether the periodicity will pad data to the nearest power of two for the Fourier transform. True by default */
+	
+	size_t c_max_total_MSD_blocks;
+	size_t c_max_nTimesamples;
+	size_t corrected_c_max_nTimesamples;
+	size_t max_nDMs;
+	size_t max_nDMs_in_memory;
+	size_t c_input_plane_size;
+	size_t c_cuFFT_workarea_size;
+	double sampling_time;
+	//std::vector<aa_periodicity_range> P_ranges;
+	std::vector<p_range_pointer> P_ranges;
+	std::vector<aa_dedispersion_range> DDTR_ranges;
+	
+	bool c_ready; /** Ready state of the instance. */
+	//--------------------------------------------------------
+	
+	void copy_plan_parameters(aa_periodicity_plan &p_plan){
+		c_sigma_cutoff = p_plan.sigma_cutoff();
+		c_sigma_outlier_rejection_threshold = p_plan.sigma_outlier_rejection_threshold();
+		c_nHarmonics = p_plan.nHarmonics();
+		c_harmonic_sum_algorithm = p_plan.harmonic_sum_algorithm();
+		c_candidate_selection_algorithm = p_plan.candidate_selection_algorithm();
+		c_enable_outlier_rejection = p_plan.enable_outlier_rejection();
+		c_enable_interbinning = p_plan.enable_interbinning();
+		c_enable_scalloping_loss_mitigation = p_plan.enable_scalloping_loss_mitigation();
+		c_enable_spectrum_whitening = p_plan.enable_spectrum_whitening();
+		c_pad_to_nearest_higher_pow2 = p_plan.pad_to_nearest_higher_pow2();
+		
+		int nRanges = p_plan.nRanges();
+		for(int f=0; f<nRanges; f++){
+			DDTR_ranges.push_back(p_plan.get_range(f));
+		}
+		c_max_nTimesamples = 0;
+		max_nDMs = 0;
+		size_t t_timesamples, t_DMs;
+		
+		if(nRanges > 0) {
+			c_max_nTimesamples = DDTR_ranges[0].nTimesamples();
+			max_nDMs = DDTR_ranges[0].nDMs();
+			sampling_time = DDTR_ranges[0].sampling_time();
+		}
+		for(int f = 1; f < nRanges; f++){
+			t_timesamples = DDTR_ranges[f].nTimesamples();
+			t_DMs = DDTR_ranges[f].nDMs();
+			if(t_timesamples > c_max_nTimesamples) c_max_nTimesamples = t_timesamples;
+			if(t_DMs > max_nDMs) max_nDMs = t_DMs;
+		}
+		
+		int nearest = (int) floorf(log2f((float) c_max_nTimesamples));
+		corrected_c_max_nTimesamples = (size_t) powf(2.0, (float) nearest);
+	}
+	
+	int Calculate_max_nDMs_in_memory(size_t memory_available, float multiple_float, float multiple_ushort) {
+		size_t t_max_nDMs_in_memory, itemp;
+		
+		size_t memory_per_DM = ((corrected_c_max_nTimesamples + 2)*(multiple_float*sizeof(float) + multiple_ushort*sizeof(ushort)));
+		LOG(log_level::debug, "   Memory required for one DM trial is " + std::to_string((float) memory_per_DM/(1024.0*1024.0)) + "MB");
+		// 1 for real input real, 2 for complex output, 2 for complex cuFFT, 1 for peaks + 1 ushort
+		t_max_nDMs_in_memory = (memory_available*0.98)/((corrected_c_max_nTimesamples+2)*(multiple_float*sizeof(float) + multiple_ushort*sizeof(ushort)));
+		if((max_nDMs + PHS_NTHREADS) < t_max_nDMs_in_memory) { //if we can fit all DM trials from largest range into memory then we need to find nearest higher multiple of PHS_NTHREADS
+			itemp = (int)(max_nDMs/PHS_NTHREADS);
+			if((max_nDMs%PHS_NTHREADS)>0) itemp++;
+			t_max_nDMs_in_memory = itemp*PHS_NTHREADS;
+		}
+		itemp = (int)(t_max_nDMs_in_memory/PHS_NTHREADS); // if we cannot fit all DM trials from largest range into memory we find nearest lower multiple of PHS_NTHREADS
+		t_max_nDMs_in_memory = itemp*PHS_NTHREADS;
+		
+		return(t_max_nDMs_in_memory);
+	}
+	
+	void Create_Periodicity_Plan() {
+		c_max_total_MSD_blocks = 0;
+		int nRanges = DDTR_ranges.size();
+		for(int f = 0; f < nRanges; f++) {
+			P_ranges.push_back( (new aa_periodicity_range(DDTR_ranges[f], corrected_c_max_nTimesamples, max_nDMs_in_memory, f)) );
+			int new_range_index = (int) P_ranges.size() - 1;
+			size_t temp = P_ranges[new_range_index]->total_MSD_blocks;
+			if(temp > c_max_total_MSD_blocks) c_max_total_MSD_blocks = temp;
+			
+		}
+	}
+	
+	size_t Get_max_c_cuFFT_workarea_size(){
+		// This whole unfortunate function is necessary because as of CUDA11 cufftMakePlan1d may return size of the cuFFT workarea larger (up to 2x) for some input values of nDMs (number of FFTs calculated). This value is larger then the value returned for some other larger value of nDMs thus we cannot rely on getting size of the cuFFT workarea just for largest number of FFT calculated.
+		//cufftHandle plan_input;
+		//cufftResult cufft_error;
+		size_t t_max_c_cuFFT_workarea_size = 0;
+		size_t temporary_c_cuFFT_workarea_size = 0;
+		
+		int nRanges = (int) P_ranges.size();
+		for(int r = 0; r < nRanges; r++) {
+			int nBatches = (int) P_ranges[r]->batches.size();
+			for(int b = 0; b < nBatches; b++) {
+				size_t nTimesamples = P_ranges[r]->batches[b].nTimesamples;
+				size_t nDMs         = P_ranges[r]->batches[b].nDMs_per_batch;
+				
+				//cufftCreate(&plan_input);
+				//cufftSetAutoAllocation(plan_input, false);
+				//cufft_error = cufftMakePlan1d(plan_input, nTimesamples, CUFFT_R2C, nDMs, &temporary_c_cuFFT_workarea_size);
+				//if (CUFFT_SUCCESS != cufft_error){
+				//	printf("CUFFT error: %d", cufft_error);
+				//}
+				//cufftDestroy(plan_input);
+				temporary_c_cuFFT_workarea_size = nDMs*nTimesamples*8;
+				
+				if(temporary_c_cuFFT_workarea_size > t_max_c_cuFFT_workarea_size) {
+					t_max_c_cuFFT_workarea_size = temporary_c_cuFFT_workarea_size;
+				}
+			}
+		}
+		
+		return(t_max_c_cuFFT_workarea_size);
+	}
+	
+	size_t Calculate_nSegments_for_spectrum_whitening(int min_segment_length, int max_segment_length, size_t nSamples){
+		size_t nSegments = 3;
+		
+		int seg_length = min_segment_length;
+		int seg_sum = 1 + seg_length;
+		while( (size_t) (seg_sum + seg_length) < nSamples) {
+			seg_sum = seg_sum + seg_length;
+			seg_length = min_segment_length*log(seg_sum);
+			if(seg_length > max_segment_length) seg_length = max_segment_length;
+			nSegments++;
+		}
+		return(nSegments);
+	}
+	
+	bool Find_Periodicity_Plan(size_t memory_available){
+		size_t memory_allocated = 0, memory_for_data = 0;
+		
+		float multiple_float  = 5.5;
+		float multiple_ushort = 2.0; 
+		LOG(log_level::debug, "> Configuring memory usage:");
+		memory_for_data = memory_available;
+		do {
+			LOG(log_level::debug, "   Memory available: " + std::to_string(memory_for_data) + " = " + std::to_string((float) memory_for_data/(1024.0*1024.0)) + "MB");
+			max_nDMs_in_memory = Calculate_max_nDMs_in_memory(memory_for_data, multiple_float, multiple_ushort);
+			if(max_nDMs_in_memory==0) {
+				LOG(log_level::error, "Error not enough memory for periodicity search!");
+				return(false);
+			}
+			c_input_plane_size = (corrected_c_max_nTimesamples + 2)*max_nDMs_in_memory;
+			memory_allocated = c_input_plane_size*multiple_float*sizeof(float) + multiple_ushort*c_input_plane_size*sizeof(ushort);
+			LOG(log_level::debug, "   Maximum number of DM trials which fit into memory is: " +  std::to_string(max_nDMs_in_memory));
+			LOG(log_level::debug, "   Maximum corrected number of time samples: " +  std::to_string(corrected_c_max_nTimesamples));
+			LOG(log_level::debug, "   Input plane size: " +  std::to_string((((float) c_input_plane_size*sizeof(float))/(1024.0*1024.0))) + " MB;")
+			
+			Create_Periodicity_Plan();
+			c_cuFFT_workarea_size = Get_max_c_cuFFT_workarea_size();
+			
+			//-------- Additional memory for MSD ------
+			int nDecimations = ((int) floorf(log2f((float)c_nHarmonics))) + 2;
+			size_t additional_data_size = c_max_total_MSD_blocks*MSD_PARTIAL_SIZE*sizeof(float) + nDecimations*2*MSD_RESULTS_SIZE*sizeof(float) + c_nHarmonics*2*sizeof(float) + 2*sizeof(int);
+			memory_allocated = memory_allocated + additional_data_size;
+			LOG(log_level::debug, "   Memory available for the component: " + std::to_string((float) memory_available/(1024.0*1024.0)) + "MB (" + std::to_string(memory_available) + " bytes)");
+			LOG(log_level::debug, "   Memory allocated by the component: " + std::to_string((float) memory_allocated/(1024.0*1024.0)) + "MB (" + std::to_string(memory_allocated) + " bytes)");
+			
+			//-------- Memory for spectrum whitening ------
+			int max_segment_length = 250;
+			int min_segment_length = 6;
+			size_t nSegments = Calculate_nSegments_for_spectrum_whitening(min_segment_length, max_segment_length, corrected_c_max_nTimesamples);
+			size_t memory_requirements_for_SW = nSegments*sizeof(int) + nSegments*sizeof(float)*max_nDMs_in_memory;
+			LOG(log_level::debug, "   Memory required for spectral whitening: " + std::to_string((float) memory_requirements_for_SW/(1024.0*1024.0)) + "MB (" + std::to_string(memory_requirements_for_SW) + " bytes)");
+			
+			if(memory_allocated>memory_available) {
+				LOG(log_level::warning, "--> Not enough memory for given configuration of periodicity plan. Calculating new plan...");
+				memory_for_data = memory_for_data - additional_data_size;
+			}
+		} while(memory_allocated > memory_available);
+		
+		LOG(log_level::debug, "   Workarea size: " + std::to_string((float) c_cuFFT_workarea_size/(1024.0*1024.0)) + "MB");
+		return(true);
+	}
+
+public:
+	aa_periodicity_strategy() {
+		c_sigma_cutoff = 10.0;
+		c_sigma_outlier_rejection_threshold = 3.0;
+		c_nHarmonics = 32;
+		c_harmonic_sum_algorithm = 1;
+		c_candidate_selection_algorithm = 1;
+		c_enable_outlier_rejection = true;
+		c_enable_interbinning = true;
+		c_enable_scalloping_loss_mitigation = true;
+		c_enable_spectrum_whitening = true;
+		c_pad_to_nearest_higher_pow2 = false;
+		
+		c_max_total_MSD_blocks = 0;
+		c_max_nTimesamples = 0;
+		corrected_c_max_nTimesamples = 0;
+		max_nDMs = 0;
+		max_nDMs_in_memory = 0;
+		c_input_plane_size = 0;
+		c_cuFFT_workarea_size = 0;
+		sampling_time = 0;
+		
+		c_ready = false;
+	}
+	
+	/** \brief Constructor for aa_periodicity_strategy that sets all member variables upon construction. */
+	aa_periodicity_strategy(aa_periodicity_plan &plan, size_t available_memory) {
+		c_ready = false;
+		LOG(log_level::debug, "------> PERIODICITY STRATEGY CONFIGURATION STARTED <------");
+		copy_plan_parameters(plan);
+		
+		bool plan_finished = Find_Periodicity_Plan(available_memory);
+		
+		if(plan_finished){
+			LOG(log_level::debug, "> Periodicity strategy configured");
+			LOG(log_level::debug, " ");
+			print_info(*this);
+		}
+		
+		if ((c_nHarmonics > 0) && (c_sigma_outlier_rejection_threshold > 0) && plan_finished) {
+			c_ready = true;
+		} 
+		else {
+			LOG(log_level::error, "Invalid periodicity strategy parameters. Check the aa_periodicity_plan input parameters.");
+			print_info(*this);
+		}
+		LOG(log_level::debug, "----------------------------------------------------------");
+	}
+	
+	/** Static member function that prints member variables for a provided aa_periodicity_strategy. */
+	static bool print_info(aa_periodicity_strategy &strategy) {
+		LOG(log_level::dev_debug, "> Periodicity strategy information:");
+		LOG(log_level::dev_debug, "  PSR - Sigma cutoff for candidate selection:\t" + std::to_string(strategy.sigma_cutoff()));
+		LOG(log_level::dev_debug, "  PSR - Enable outlier rejection:\t\t" + (strategy.candidate_selection_algorithm() ? std::string("true") : std::string("false")));
+		LOG(log_level::dev_debug, "  PSR - Sigma cutoff for outlier rejection:\t" + std::to_string(strategy.sigma_outlier_rejection_threshold()));
+		LOG(log_level::dev_debug, "  PSR - Number of harmonics:\t\t\t" + std::to_string(strategy.nHarmonics()));
+		LOG(log_level::dev_debug, "  PSR - Harmonic sum algorithm:\t\t\t" + std::to_string(strategy.harmonic_sum_algorithm()));
+		LOG(log_level::dev_debug, "  PSR - Candidate selection algorithm:\t\t" + std::to_string(strategy.candidate_selection_algorithm()));
+		LOG(log_level::dev_debug, "  PSR - Enable interbinning:\t\t\t" + (strategy.enable_interbinning() ? std::string("true") : std::string("false")));
+		LOG(log_level::dev_debug, "  PSR - Enable scalloping loss mitigation:\t" + (strategy.enable_scalloping_loss_mitigation() ? std::string("true") : std::string("false")));
+		LOG(log_level::dev_debug, "  PSR - Enable spectrum whitening:\t\t" + (strategy.enable_spectrum_whitening() ? std::string("true") : std::string("false")));
+		LOG(log_level::dev_debug, "  PSR - Pad to the nearest higher power of 2:\t" + (strategy.pad_to_nearest_higher_pow2() ? std::string("true") : std::string("false")));
+		LOG(log_level::dev_debug, " ");
+		strategy.print_dedispersion_plan();
+		LOG(log_level::dev_debug, " ");
+		strategy.print_periodicity_ranges();
+		
+		return true;
+	}
+	
+	/** \brief Method for printing member variable information. */
+	void print_dedispersion_plan() {
+		LOG(log_level::debug, "> De-dispersion plan used:");
+		LOG(log_level::debug, "   sampling time: " + std::to_string(sampling_time));
+		LOG(log_level::debug, "   processed time samples by de-dispersion: " + std::to_string(c_max_nTimesamples));
+		LOG(log_level::debug, "   corrected time samples for FFT: " + std::to_string(corrected_c_max_nTimesamples));
+		LOG(log_level::debug, "   maximum number of DM trials: " + std::to_string(max_nDMs));
+		for(int f=0; f<(int)DDTR_ranges.size(); f++) {
+			DDTR_ranges[f].print();
+		}
+	}
+	
+	/** \brief Method for printing member variable information. */
+	void print_periodicity_ranges() {
+		int nPranges = (int) P_ranges.size();
+		LOG(log_level::debug, "> Periodicity execution information:");
+		LOG(log_level::debug, "  Number of periodicity ranges: " + std::to_string(nPranges));
+		for(int r=0;r<nPranges;r++){
+			P_ranges[r]->print();
+		}
+	}
+	
+	/** \returns The ready state of the instance of the class. */
+	bool ready() const {
+		return c_ready;
+	}
+	
+	/** \brief Performs any remaining setup needed.
+	 * \returns Whether the operation was successful or not, at the moment this is the ready state of the instance. */
+	bool setup() {
+		return ready();
+	}
+
+	/** \returns The name of the module. */
+	std::string name() const {
+		return "periodicity_strategy";
+	}
+
+
+
+	//----------------------------- Getters ---------------------------
+	
+	int nRanges() const {
+		return((int)DDTR_ranges.size());
+	}
+
+	aa_periodicity_range get_periodicity_range(size_t id) {
+		return( *(P_ranges.at(id)) );
+	}
+
+	float sigma_cutoff() const {
+		return c_sigma_cutoff;
+	}
+
+	float sigma_outlier_rejection_threshold() const {
+		return c_sigma_outlier_rejection_threshold;
+	}
+
+	/** \returns A number of harmonics used in harmonic summing algorithm. */
+	int nHarmonics() const {
+		return c_nHarmonics;
+	}
+
+	/** \returns type of the harmonic sum algorithm used. */
+	int harmonic_sum_algorithm() const {
+		return c_harmonic_sum_algorithm;
+	}
+
+	/** \returns type of the reduction algorithm for candidate selection. */
+	int candidate_selection_algorithm() const {
+		return c_candidate_selection_algorithm;
+	}
+
+	/** \returns A boolean indicating whether the outlier rejection will be enabled, for an instance of aa_periodicity_strategy. */
+	bool enable_outlier_rejection() const {
+		return c_enable_outlier_rejection;
+	}
+
+	/** \returns A boolean indicating whether the interpolation will be enabled, for an instance of aa_periodicity_strategy. */
+	bool enable_interbinning() const {
+		return(c_enable_interbinning);
+	}
+
+	/** \returns A boolean indicating whether 5-point convolution scalloping loss mitigation is enabled. */
+	bool enable_scalloping_loss_mitigation() const {
+		return(c_enable_scalloping_loss_mitigation);
+	}
+
+	/** \returns A boolean indicating whether the spectrum whitening will be enabled, for an instance of aa_periodicity_strategy. */
+	bool enable_spectrum_whitening() const {
+		return(c_enable_spectrum_whitening);
+	}
+
+	/** \returns A boolean indicating whether the time-series will be padded to nearest power of two. */
+	bool pad_to_nearest_higher_pow2() const {
+		return(c_pad_to_nearest_higher_pow2);
+	}
+	
+	/** \returns Memory block size required for periodicity search, but not total memory. */
+	size_t input_plane_size(){
+		return(c_input_plane_size);
+	}
+	
+	/** \returns Memory block size required for MSD calculation. */
+	size_t max_total_MSD_blocks(){
+		return(c_max_total_MSD_blocks);
+	}
+	
+	/** \returns Memory block size required for cuFFT calculation. */
+	size_t cuFFT_workarea_size(){
+		return(c_cuFFT_workarea_size);
+	}
+	
+	/** \returns Memory block size required for cuFFT calculation. */
+	size_t max_nTimesamples(){
+		return(c_max_nTimesamples);
+	}
+
+};
 
 } // namespace astroaccelerate
 

--- a/include/aa_permitted_pipelines_3.hpp
+++ b/include/aa_permitted_pipelines_3.hpp
@@ -36,7 +36,7 @@ namespace astroaccelerate {
    * \class aa_permitted_pipelines_3 aa_permitted_pipelines_3.hpp "include/aa_permitted_pipelines_3.hpp"
    * \brief Templated class to run dedispersion and analysis and periodicity.
    * \details The class is templated over the zero_dm_type (aa_pipeline::component_option::zero_dm or aa_pipeline::component_option::zero_dm_with_outliers).
-   * \author Cees Carels.
+   * \author AstroAccelerate
    * \date 28 November 2018.
    */
 
@@ -500,8 +500,6 @@ namespace astroaccelerate {
       timer.Start();
       const int *ndms =	m_ddtr_strategy.ndms_data();
       GPU_periodicity(m_ddtr_strategy.get_nRanges(),
-		      m_ddtr_strategy.metadata().nsamples(),
-		      max_ndms,
 		      inc,
 		      m_periodicity_strategy.sigma_cutoff(),
 		      m_output_buffer,

--- a/include/aa_permitted_pipelines_3.hpp
+++ b/include/aa_permitted_pipelines_3.hpp
@@ -11,6 +11,7 @@
 #include "aa_analysis_plan.hpp"
 #include "aa_analysis_strategy.hpp"
 #include "aa_periodicity_strategy.hpp"
+#include "aa_periodicity_candidates.hpp"
 
 #include "aa_filterbank_metadata.hpp"
 #include "aa_device_load_data.hpp"
@@ -125,6 +126,9 @@ namespace astroaccelerate {
 	cudaFree(m_d_MSD_workarea);
         cudaFree(m_d_MSD_output_taps);
 	cudaFree(m_d_MSD_interpolated);
+	
+	c_PSR_power_candidates.Free_candidates();
+	c_PSR_interbin_candidates.Free_candidates();
 
 	size_t t_processed_size = m_ddtr_strategy.t_processed().size();
 	for(size_t i = 0; i < t_processed_size; i++) {
@@ -162,6 +166,10 @@ namespace astroaccelerate {
 
     unsigned short     *d_input;
     float              *d_output;
+    
+    // periodicity search output candidates
+    aa_periodicity_candidates c_PSR_power_candidates;
+    aa_periodicity_candidates c_PSR_interbin_candidates;
     
     std::vector<float> dm_low;
     std::vector<float> dm_high;
@@ -501,7 +509,9 @@ namespace astroaccelerate {
       const int *ndms =	m_ddtr_strategy.ndms_data();
       GPU_periodicity(
         m_periodicity_strategy,
-        m_output_buffer
+        m_output_buffer,
+        c_PSR_power_candidates,
+        c_PSR_interbin_candidates
       );
       
       timer.Stop();

--- a/include/aa_permitted_pipelines_3.hpp
+++ b/include/aa_permitted_pipelines_3.hpp
@@ -499,20 +499,10 @@ namespace astroaccelerate {
       aa_gpu_timer timer;
       timer.Start();
       const int *ndms =	m_ddtr_strategy.ndms_data();
-      GPU_periodicity(m_ddtr_strategy.get_nRanges(),
-		      inc,
-		      m_periodicity_strategy.sigma_cutoff(),
-		      m_output_buffer,
-		      ndms,
-		      inBin.data(),
-		      dm_low.data(),
-		      dm_high.data(),
-		      dm_step.data(),
-		      tsamp_original,
-		      m_periodicity_strategy.nHarmonics(),
-		      m_periodicity_strategy.candidate_algorithm(),
-		      m_periodicity_strategy.enable_msd_baseline_noise(),
-		      m_periodicity_strategy.sigma_constant());
+      GPU_periodicity(
+        m_periodicity_strategy,
+        m_output_buffer
+      );
       
       timer.Stop();
       float time = timer.Elapsed()/1000;

--- a/include/aa_permitted_pipelines_3_0.hpp
+++ b/include/aa_permitted_pipelines_3_0.hpp
@@ -11,6 +11,7 @@
 
 
 #include "aa_periodicity_strategy.hpp"
+#include "aa_periodicity_candidates.hpp"
 
 #include "aa_filterbank_metadata.hpp"
 #include "aa_device_load_data.hpp"
@@ -95,6 +96,9 @@ namespace astroaccelerate {
       if(memory_allocated && !memory_cleanup) {
 	cudaFree(d_input);
 	cudaFree(d_output);
+	
+	c_PSR_power_candidates.Free_candidates();
+	c_PSR_interbin_candidates.Free_candidates();
 
 	size_t t_processed_size = m_ddtr_strategy.t_processed().size();
 	for(size_t i = 0; i < t_processed_size; i++) {
@@ -131,6 +135,10 @@ namespace astroaccelerate {
 
     unsigned short     *d_input;
     float              *d_output;
+    
+    // periodicity search output candidates
+    aa_periodicity_candidates c_PSR_power_candidates;
+    aa_periodicity_candidates c_PSR_interbin_candidates;
     
     std::vector<float> dm_low;
     std::vector<float> dm_high;
@@ -382,7 +390,9 @@ namespace astroaccelerate {
       const int *ndms =	m_ddtr_strategy.ndms_data();
       GPU_periodicity(
         m_periodicity_strategy,
-        m_output_buffer
+        m_output_buffer,
+        c_PSR_power_candidates,
+        c_PSR_interbin_candidates
       );
       
       timer.Stop();

--- a/include/aa_permitted_pipelines_3_0.hpp
+++ b/include/aa_permitted_pipelines_3_0.hpp
@@ -35,7 +35,7 @@ namespace astroaccelerate {
    * \class aa_permitted_pipelines_3_0 aa_permitted_pipelines_3_0.hpp "include/aa_permitted_pipelines_3_0.hpp"
    * \brief Templated class to run dedispersion and periodicity.
    * \details The class is templated over the zero_dm_type (aa_pipeline::component_option::zero_dm or aa_pipeline::component_option::zero_dm_with_outliers).
-   * \author Cees Carels.
+   * \author AstroAccelerate
    * \date 28 November 2018.
    */
 
@@ -381,8 +381,6 @@ namespace astroaccelerate {
       timer.Start();
       const int *ndms =	m_ddtr_strategy.ndms_data();
       GPU_periodicity(m_ddtr_strategy.get_nRanges(),
-		      m_ddtr_strategy.metadata().nsamples(),
-		      max_ndms,
 		      inc,
 		      m_periodicity_strategy.sigma_cutoff(),
 		      m_output_buffer,

--- a/include/aa_permitted_pipelines_3_0.hpp
+++ b/include/aa_permitted_pipelines_3_0.hpp
@@ -380,20 +380,10 @@ namespace astroaccelerate {
       aa_gpu_timer timer;
       timer.Start();
       const int *ndms =	m_ddtr_strategy.ndms_data();
-      GPU_periodicity(m_ddtr_strategy.get_nRanges(),
-		      inc,
-		      m_periodicity_strategy.sigma_cutoff(),
-		      m_output_buffer,
-		      ndms,
-		      inBin.data(),
-		      dm_low.data(),
-		      dm_high.data(),
-		      dm_step.data(),
-		      tsamp_original,
-		      m_periodicity_strategy.nHarmonics(),
-		      m_periodicity_strategy.candidate_algorithm(),
-		      m_periodicity_strategy.enable_msd_baseline_noise(),
-		      m_periodicity_strategy.sigma_constant());
+      GPU_periodicity(
+        m_periodicity_strategy,
+        m_output_buffer
+      );
       
       timer.Stop();
       float time = timer.Elapsed()/1000;

--- a/include/aa_permitted_pipelines_5.hpp
+++ b/include/aa_permitted_pipelines_5.hpp
@@ -11,6 +11,7 @@
 #include "aa_analysis_plan.hpp"
 #include "aa_analysis_strategy.hpp"
 #include "aa_periodicity_strategy.hpp"
+#include "aa_periodicity_candidates.hpp"
 #include "aa_fdas_strategy.hpp"
 
 #include "aa_filterbank_metadata.hpp"
@@ -108,6 +109,9 @@ namespace astroaccelerate {
 	cudaFree(m_d_MSD_output_taps);
 	cudaFree(m_d_MSD_interpolated);
 	
+	c_PSR_power_candidates.Free_candidates();
+	c_PSR_interbin_candidates.Free_candidates();
+	
 	size_t t_processed_size = m_ddtr_strategy.t_processed().size();
 	for(size_t i = 0; i < t_processed_size; i++) {
 	  free(t_processed[i]);
@@ -145,6 +149,10 @@ namespace astroaccelerate {
 
     unsigned short     *d_input;
     float              *d_output;
+    
+    // periodicity search output candidates
+    aa_periodicity_candidates c_PSR_power_candidates;
+    aa_periodicity_candidates c_PSR_interbin_candidates;
     
     std::vector<float> dm_low;
     std::vector<float> dm_high;
@@ -503,7 +511,9 @@ namespace astroaccelerate {
       
       GPU_periodicity(
         m_periodicity_strategy,
-        m_output_buffer
+        m_output_buffer,
+        c_PSR_power_candidates,
+        c_PSR_interbin_candidates
       );
       
       timer.Stop();

--- a/include/aa_permitted_pipelines_5.hpp
+++ b/include/aa_permitted_pipelines_5.hpp
@@ -38,7 +38,7 @@ namespace astroaccelerate {
    * \class aa_permitted_pipelines_5 aa_permitted_pipelines_5.hpp "include/aa_permitted_pipelines_5.hpp"
    * \brief Templated class to run dedispersion and analysis and periodicity and acceleration.
    * \details The class is templated over the zero_dm_type (aa_pipeline::component_option::zero_dm or aa_pipeline::component_option::zero_dm_with_outliers).
-   * \author Cees Carels.
+   * \author AstroAccelerate
    * \date 3 December 2018.
    */
   
@@ -502,8 +502,6 @@ namespace astroaccelerate {
       timer.Start();
       const int *ndms =	m_ddtr_strategy.ndms_data();
       GPU_periodicity(m_ddtr_strategy.get_nRanges(),
-		      m_ddtr_strategy.metadata().nsamples(),
-		      max_ndms,
 		      inc,
 		      m_periodicity_strategy.sigma_cutoff(),
 		      m_output_buffer,

--- a/include/aa_permitted_pipelines_5.hpp
+++ b/include/aa_permitted_pipelines_5.hpp
@@ -500,21 +500,11 @@ namespace astroaccelerate {
       cleanup();
       aa_gpu_timer timer;
       timer.Start();
-      const int *ndms =	m_ddtr_strategy.ndms_data();
-      GPU_periodicity(m_ddtr_strategy.get_nRanges(),
-		      inc,
-		      m_periodicity_strategy.sigma_cutoff(),
-		      m_output_buffer,
-		      ndms,
-		      inBin.data(),
-		      dm_low.data(),
-		      dm_high.data(),
-		      dm_step.data(),
-		      tsamp_original,
-		      m_periodicity_strategy.nHarmonics(),
-		      m_periodicity_strategy.candidate_algorithm(),
-		      m_periodicity_strategy.enable_msd_baseline_noise(),
-		      m_periodicity_strategy.sigma_constant());
+      
+      GPU_periodicity(
+        m_periodicity_strategy,
+        m_output_buffer
+      );
       
       timer.Stop();
       float time = timer.Elapsed()/1000;

--- a/include/aa_permitted_pipelines_5_0.hpp
+++ b/include/aa_permitted_pipelines_5_0.hpp
@@ -11,6 +11,7 @@
 
 
 #include "aa_periodicity_strategy.hpp"
+#include "aa_periodicity_candidates.hpp"
 #include "aa_fdas_strategy.hpp"
 
 #include "aa_filterbank_metadata.hpp"
@@ -104,6 +105,9 @@ namespace astroaccelerate {
 	cudaFree(d_input);
 	cudaFree(d_output);
 	
+	c_PSR_power_candidates.Free_candidates();
+	c_PSR_interbin_candidates.Free_candidates();
+	
 	size_t t_processed_size = m_ddtr_strategy.t_processed().size();
 	for(size_t i = 0; i < t_processed_size; i++) {
 	  free(t_processed[i]);
@@ -140,6 +144,10 @@ namespace astroaccelerate {
 
     unsigned short     *d_input;
     float              *d_output;
+    
+    // periodicity search output candidates
+    aa_periodicity_candidates c_PSR_power_candidates;
+    aa_periodicity_candidates c_PSR_interbin_candidates;
     
     std::vector<float> dm_low;
     std::vector<float> dm_high;
@@ -413,7 +421,9 @@ namespace astroaccelerate {
       
       GPU_periodicity(
         m_periodicity_strategy,
-        m_output_buffer
+        m_output_buffer,
+        c_PSR_power_candidates,
+        c_PSR_interbin_candidates
       );
       
       timer.Stop();

--- a/include/aa_permitted_pipelines_5_0.hpp
+++ b/include/aa_permitted_pipelines_5_0.hpp
@@ -38,7 +38,7 @@ namespace astroaccelerate {
    * \class aa_permitted_pipelines_5_0 aa_permitted_pipelines_5_0.hpp "include/aa_permitted_pipelines_5_0.hpp"
    * \brief Templated class to run dedispersion and periodicity and acceleration.
    * \details The class is templated over the zero_dm_type (aa_pipeline::component_option::zero_dm or aa_pipeline::component_option::zero_dm_with_outliers).
-   * \author Cees Carels.
+   * \author AstroAccelerate
    * \date 3 December 2018.
    */
   
@@ -412,8 +412,6 @@ namespace astroaccelerate {
       timer.Start();
       const int *ndms =	m_ddtr_strategy.ndms_data();
       GPU_periodicity(m_ddtr_strategy.get_nRanges(),
-		      m_ddtr_strategy.metadata().nsamples(),
-		      max_ndms,
 		      inc,
 		      m_periodicity_strategy.sigma_cutoff(),
 		      m_output_buffer,

--- a/include/aa_permitted_pipelines_5_0.hpp
+++ b/include/aa_permitted_pipelines_5_0.hpp
@@ -410,21 +410,11 @@ namespace astroaccelerate {
       cleanup();
       aa_gpu_timer timer;
       timer.Start();
-      const int *ndms =	m_ddtr_strategy.ndms_data();
-      GPU_periodicity(m_ddtr_strategy.get_nRanges(),
-		      inc,
-		      m_periodicity_strategy.sigma_cutoff(),
-		      m_output_buffer,
-		      ndms,
-		      inBin.data(),
-		      dm_low.data(),
-		      dm_high.data(),
-		      dm_step.data(),
-		      tsamp_original,
-		      m_periodicity_strategy.nHarmonics(),
-		      m_periodicity_strategy.candidate_algorithm(),
-		      m_periodicity_strategy.enable_msd_baseline_noise(),
-		      m_periodicity_strategy.sigma_constant());
+      
+      GPU_periodicity(
+        m_periodicity_strategy,
+        m_output_buffer
+      );
       
       timer.Stop();
       float time = timer.Elapsed()/1000;

--- a/include/aa_permitted_pipelines_generic.hpp
+++ b/include/aa_permitted_pipelines_generic.hpp
@@ -822,8 +822,6 @@ namespace astroaccelerate {
 			timer.Start();
 			const int *ndms = m_ddtr_strategy.ndms_data();
 			GPU_periodicity(m_ddtr_strategy.get_nRanges(),
-				m_ddtr_strategy.metadata().nsamples(),
-				max_ndms,
 				inc,
 				m_periodicity_strategy.sigma_cutoff(),
 				m_output_buffer,

--- a/include/aa_permitted_pipelines_generic.hpp
+++ b/include/aa_permitted_pipelines_generic.hpp
@@ -532,6 +532,7 @@ namespace astroaccelerate {
 			const aa_pipeline::component_option opt_zero_dm                = aa_pipeline::component_option::zero_dm;
 			const aa_pipeline::component_option opt_zero_dm_with_outliers  = aa_pipeline::component_option::zero_dm_with_outliers;
 			const aa_pipeline::component_option opt_old_rfi                = aa_pipeline::component_option::old_rfi;
+			//const aa_pipeline::component_option opt_dered                  = aa_pipeline::component_option::dered;
 			
 			//------------------------------------> Error checking
 			if(pipeline_error!=0) {

--- a/include/aa_permitted_pipelines_generic.hpp
+++ b/include/aa_permitted_pipelines_generic.hpp
@@ -820,21 +820,11 @@ namespace astroaccelerate {
 			if (periodicity_did_run) return false;
 			aa_gpu_timer timer;
 			timer.Start();
-			const int *ndms = m_ddtr_strategy.ndms_data();
-			GPU_periodicity(m_ddtr_strategy.get_nRanges(),
-				inc,
-				m_periodicity_strategy.sigma_cutoff(),
-				m_output_buffer,
-				ndms,
-				inBin.data(),
-				dm_low.data(),
-				dm_high.data(),
-				dm_step.data(),
-				tsamp_original,
-				m_periodicity_strategy.nHarmonics(),
-				m_periodicity_strategy.candidate_algorithm(),
-				m_periodicity_strategy.enable_msd_baseline_noise(),
-				m_periodicity_strategy.sigma_constant());
+			
+			GPU_periodicity(
+				m_periodicity_strategy,
+				m_output_buffer
+			);
 
 			timer.Stop();
 			time_log.adding("Periodicity", "total", timer.Elapsed());

--- a/include/aa_pipeline_api.hpp
+++ b/include/aa_pipeline_api.hpp
@@ -1125,6 +1125,32 @@ namespace astroaccelerate {
 		size_t SPD_nCandidates(){
 			return m_runner->get_SPD_nCandidates();
 		}
+		
+		// ----------------------- PSR -------------------------
+		float *Get_PSR_candidates(){
+			return m_runner->Get_PSR_candidates();
+		}
+		
+		float *Get_PSR_interbin_candidates(){
+			return m_runner->Get_PSR_interbin_candidates();
+		}
+		
+		void Write_to_disk_PSR_candidates(const char *filename){
+			m_runner->Write_to_disk_PSR_candidates(filename);
+		}
+		
+		void Write_to_disk_PSR_interbin_candidates(const char *filename){
+			m_runner->Write_to_disk_PSR_interbin_candidates(filename);
+		}
+		
+		size_t get_PSR_nCandidates(){
+			return m_runner->get_PSR_nCandidates();
+		}
+		
+		size_t get_PSR_interbin_nCandidates(){
+			return m_runner->get_PSR_interbin_nCandidates();
+		}
+		// ----------------------- PSR -------------------------
 
 		int get_current_range(){
 			return m_runner->get_current_range();

--- a/include/aa_pipeline_api.hpp
+++ b/include/aa_pipeline_api.hpp
@@ -233,8 +233,10 @@ namespace astroaccelerate {
 
 			//Does the pipeline actually need this plan?
 			if (required_plans.find(aa_pipeline::component::periodicity) != required_plans.end()) {
+				size_t free_mem, total_mem;
+				cudaMemGetInfo(&free_mem,&total_mem);
 				m_periodicity_plan = plan;
-				aa_periodicity_strategy periodicity_strategy(m_periodicity_plan);
+				aa_periodicity_strategy periodicity_strategy(m_periodicity_plan, free_mem);
 				if (periodicity_strategy.ready()) {
 					m_periodicity_strategy = std::move(periodicity_strategy);
 					m_all_strategy.push_back(&m_periodicity_strategy);

--- a/include/aa_pipeline_generic.hpp
+++ b/include/aa_pipeline_generic.hpp
@@ -29,9 +29,8 @@ namespace astroaccelerate {
 			   const float &analysis_max_boxcar_width_in_sec = 0.0,
 			   const bool  &analysis_enable_msd_baseline_noise_algorithm = false,
 			   const float &periodicity_sigma_cutoff = 0.0,
-			   const float &periodicity_sigma_constant = 0.0,
+			   const float &periodicity_sigma_outlier_rejection_threshold = 0.0,
 			   const int   &periodicity_nHarmonics = 0.0,
-			   const int   &periodicity_export_powers = 0,
 			   const bool  &periodicity_candidate_algorithm = false,
 			   const bool  &periodicity_enable_outlier_rejection = false) {
     /**
@@ -118,12 +117,13 @@ namespace astroaccelerate {
 				   analysis_enable_msd_baseline_noise_algorithm);
     pipeline_manager.bind(analysis_plan);
 
-    aa_periodicity_plan periodicity_plan(periodicity_sigma_cutoff,
-					 periodicity_sigma_constant,
+    aa_periodicity_plan periodicity_plan(
+					 pipeline_manager.ddtr_strategy(),
+					 periodicity_sigma_cutoff,
+					 periodicity_enable_outlier_rejection,
+					 periodicity_sigma_outlier_rejection_threshold,
 					 periodicity_nHarmonics,
-					 periodicity_export_powers,
-					 periodicity_candidate_algorithm,
-					 periodicity_enable_outlier_rejection);
+					 periodicity_candidate_algorithm);
     pipeline_manager.bind(periodicity_plan);
     
     // Bind further plans as necessary

--- a/include/aa_pipeline_runner.hpp
+++ b/include/aa_pipeline_runner.hpp
@@ -114,11 +114,11 @@ namespace astroaccelerate {
 			return(NULL);
 		}
 		
-		virtual void Write_to_disk_PSR_candidates(const char *filename){
+		virtual void Write_to_disk_PSR_candidates(const char *){
 			LOG(log_level::error, "The selected operation is not supported on this pipeline (current_range).");
 		}
 		
-		virtual void Write_to_disk_PSR_interbin_candidates(const char *filename){
+		virtual void Write_to_disk_PSR_interbin_candidates(const char *){
 			LOG(log_level::error, "The selected operation is not supported on this pipeline (current_range).");
 		}
 		

--- a/include/aa_pipeline_runner.hpp
+++ b/include/aa_pipeline_runner.hpp
@@ -102,6 +102,36 @@ namespace astroaccelerate {
 			LOG(log_level::error, "The selected operation is not supported on this pipeline (nCandidates).");
 			return 0;
 		}
+		
+		// ----------------------- PSR -------------------------
+		virtual float *Get_PSR_candidates(){
+			LOG(log_level::error, "The selected operation is not supported on this pipeline (current_range).");
+			return(NULL);
+		}
+		
+		virtual float *Get_PSR_interbin_candidates(){
+			LOG(log_level::error, "The selected operation is not supported on this pipeline (current_range).");
+			return(NULL);
+		}
+		
+		virtual void Write_to_disk_PSR_candidates(const char *filename){
+			LOG(log_level::error, "The selected operation is not supported on this pipeline (current_range).");
+		}
+		
+		virtual void Write_to_disk_PSR_interbin_candidates(const char *filename){
+			LOG(log_level::error, "The selected operation is not supported on this pipeline (current_range).");
+		}
+		
+		virtual size_t get_PSR_nCandidates(){
+			LOG(log_level::error, "The selected operation is not supported on this pipeline (current_range).");
+			return(0);
+		}
+
+		virtual size_t get_PSR_interbin_nCandidates(){
+			LOG(log_level::error, "The selected operation is not supported on this pipeline (current_range).");
+			return(0);
+		}
+		// ----------------------- PSR -------------------------
 
 		virtual int get_current_range(){
 			LOG(log_level::error, "The selected operation is not supported on this pipeline (current_range).");

--- a/include/aa_py_pipeline_api.hpp
+++ b/include/aa_py_pipeline_api.hpp
@@ -53,7 +53,7 @@ namespace astroaccelerate {
       bool aa_py_pipeline_api_bind_analysis_plan(aa_pipeline_api<unsigned short> *const obj, aa_analysis_plan const*const plan);
       aa_analysis_strategy* aa_py_pipeline_api_analysis_strategy(aa_pipeline_api<unsigned short> *const obj);
 
-      bool aa_py_pipeline_api_bind_periodicity_plan(aa_pipeline_api<unsigned short> *const obj, const float sigma_cutoff, const float sigma_constant, const int nHarmonics, const int export_powers, const bool candidate_algorithm, const bool enable_msd_baseline_noise);
+      bool aa_py_pipeline_api_bind_periodicity_plan(aa_pipeline_api<unsigned short> *const obj, const float sigma_cutoff, const bool enable_outlier_rejection, const float sigma_outlier_rejection_threshold, const int nHarmonics, const int candidate_selection_algorithm);
 
       bool aa_py_pipeline_api_bind_fdas_plan(aa_pipeline_api<unsigned short> *const obj, const float sigma_cutoff, const float sigma_constant, const bool enable_msd_baseline_noise);
 

--- a/src/aa_device_harmonic_summing.cu
+++ b/src/aa_device_harmonic_summing.cu
@@ -3,6 +3,7 @@
 
 #include "aa_params.hpp"
 #include "aa_device_harmonic_summing_kernel.hpp"
+#include <stdio.h>
 
 namespace astroaccelerate {
 
@@ -46,12 +47,14 @@ namespace astroaccelerate {
       int nHarmonics,
       int enable_scalloping_loss_removal
   ){
+    int nThreads = HRMS_ConstParams::nThreads;
+    
     //---------> Task specific
     int nBlocks_x, nBlocks_y;
-    nBlocks_x = (nTimesamples + GHRMS_NTHREADS - 1)/GHRMS_NTHREADS;
+    nBlocks_x = (nTimesamples + nThreads - 1)/nThreads;
     nBlocks_y = nDMs;
     dim3 gridSize(nBlocks_x, nBlocks_y, 1);
-    dim3 blockSize(GHRMS_NTHREADS, 1, 1);
+    dim3 blockSize(nThreads, 1, 1);
     
     #ifdef HS_DEBUG
     if(DEBUG) printf("Data dimensions: %zu x %zu;\n",nDMs, nTimesamples);
@@ -88,12 +91,14 @@ namespace astroaccelerate {
       int nHarmonics,
       int enable_scalloping_loss_removal
   ) {
+    int nThreads = HRMS_ConstParams::nThreads;
+    
     //---------> Task specific
     int nBlocks_x, nBlocks_y;
-    nBlocks_x = (nTimesamples + GHRMS_NTHREADS - 1)/GHRMS_NTHREADS;
+    nBlocks_x = (nTimesamples + nThreads - 1)/nThreads;
     nBlocks_y = nDMs;
     dim3 gridSize(nBlocks_x, nBlocks_y, 1);
-    dim3 blockSize(GHRMS_NTHREADS, 1, 1);
+    dim3 blockSize(nThreads, 1, 1);
     
     #ifdef HS_DEBUG
     if(DEBUG) printf("Data dimensions: %zu x %zu;\n",nDMs, nTimesamples);
@@ -120,7 +125,6 @@ namespace astroaccelerate {
     return(0);
   }
   
-  /*
   int periodicity_presto_harmonic_summing(
       float *d_input,
       float *d_output_SNR,
@@ -131,12 +135,15 @@ namespace astroaccelerate {
       int nHarmonics,
       int enable_scalloping_loss_removal
   ) {
+    int nThreads = HRMS_ConstParams::nThreads;
+    
     //---------> Task specific
     int nBlocks_x, nBlocks_y;
-    nBlocks_x = (nTimesamples + GHRMS_NTHREADS - 1)/GHRMS_NTHREADS;
+    nBlocks_x = (nTimesamples + nThreads - 1)/nThreads;
     nBlocks_y = nDMs;
     dim3 gridSize(nBlocks_x, nBlocks_y, 1);
-    dim3 blockSize(GHRMS_NTHREADS, 1, 1);
+    dim3 blockSize(nThreads, 1, 1);
+    int nHarmonicsFactor = (int) (log(nHarmonics)/log(2.0)) + 1;
     
     #ifdef HS_DEBUG
     if(DEBUG) printf("Data dimensions: %zu x %zu;\n",nDMs, nTimesamples);
@@ -156,12 +163,11 @@ namespace astroaccelerate {
         d_MSD,
         nTimesamples,
         nDMs,
-        nHarmonics,
+        nHarmonicsFactor,
         enable_scalloping_loss_removal
     );
     
     return(0);
   }
-  */
   
 } //namespace astroaccelerate

--- a/src/aa_device_harmonic_summing.cu
+++ b/src/aa_device_harmonic_summing.cu
@@ -7,49 +7,116 @@
 namespace astroaccelerate {
 
   /** \brief Computes a simple harmonic sum for periodicity. */
-  void periodicity_simple_harmonic_summing_old(float *d_input, float *d_output_SNR, ushort *d_output_harmonics, float *d_MSD, int nTimesamples, int nSpectra, int nHarmonics){
+  int periodicity_simple_harmonic_summing(
+      float *d_input, 
+      float *d_output_SNR,
+      ushort *d_output_harmonics,
+      float *d_MSD,
+      int nTimesamples,
+      int nDMs,
+      int nHarmonics
+  ){
     //---------> Task specific
     int nBlocks_x, nBlocks_y;
-
     nBlocks_x = nTimesamples;
-    nBlocks_y = nSpectra/PHS_NTHREADS;
-    if ( nSpectra%PHS_NTHREADS !=0 ) nBlocks_y++;
-	
+    nBlocks_y = (nDMs + PHS_NTHREADS - 1)/PHS_NTHREADS;
     dim3 gridSize(nBlocks_x, nBlocks_y, 1);
     dim3 blockSize(PHS_NTHREADS, 1, 1);
-	
-#ifdef HS_DEBUG
-    printf("Data dimensions: %d x %d;\n", nSpectra, nTimesamples);
+    
+    #ifdef HS_DEBUG
+    printf("Data dimensions: %d x %d;\n", nDMs, nTimesamples);
     printf("Grid  settings: x:%d; y:%d; z:%d;\n", gridSize.x, gridSize.y, gridSize.z);
     printf("Block settings: x:%d; y:%d; z:%d;\n", blockSize.x, blockSize.y, blockSize.z);
-#endif
-	
+    #endif
+    
     cudaDeviceSetCacheConfig(cudaFuncCachePreferL1);
     cudaDeviceSetSharedMemConfig(cudaSharedMemBankSizeFourByte);
-    call_kernel_PHS_GPU_kernel_old(gridSize,blockSize, d_input, d_output_SNR, d_output_harmonics, d_MSD, nTimesamples, nSpectra, nHarmonics);
+    call_kernel_simple_harmonic_sum_GPU_kernel(gridSize, blockSize, d_input, d_output_SNR, d_output_harmonics, d_MSD, nTimesamples, nDMs, nHarmonics);
+    
+    return(0);
   }
 
-  /** \brief Computes a simple harmonic sum for periodicity. */
-  void periodicity_simple_harmonic_summing(float *d_input, float *d_output_SNR, ushort *d_output_harmonics, float *d_MSD, int nTimesamples, int nSpectra, int nHarmonics){
+  int periodicity_greedy_harmonic_summing(
+      float *d_input,
+      float *d_output_SNR,
+      ushort *d_output_harmonics,
+      float *d_MSD,
+      int nTimesamples,
+      int nDMs,
+      int nHarmonics,
+      int enable_scalloping_loss_removal
+  ){
     //---------> Task specific
     int nBlocks_x, nBlocks_y;
-
-    nBlocks_x = nTimesamples;
-    nBlocks_y = nSpectra/PHS_NTHREADS;
-    if ( nSpectra%PHS_NTHREADS !=0 ) nBlocks_y++;
-	
+    nBlocks_x = (nTimesamples + GHRMS_NTHREADS - 1)/GHRMS_NTHREADS;
+    nBlocks_y = nDMs;
     dim3 gridSize(nBlocks_x, nBlocks_y, 1);
-    dim3 blockSize(PHS_NTHREADS, 1, 1);
-	
-#ifdef HS_DEBUG
-    printf("Data dimensions: %d x %d;\n", nSpectra, nTimesamples);
-    printf("Grid  settings: x:%d; y:%d; z:%d;\n", gridSize.x, gridSize.y, gridSize.z);
-    printf("Block settings: x:%d; y:%d; z:%d;\n", blockSize.x, blockSize.y, blockSize.z);
-#endif
-	
+    dim3 blockSize(GHRMS_NTHREADS, 1, 1);
+    
+    #ifdef HS_DEBUG
+    if(DEBUG) printf("Data dimensions: %zu x %zu;\n",nDMs, nTimesamples);
+    if(DEBUG) printf("Grid  settings: x:%d; y:%d; z:%d;\n", gridSize.x, gridSize.y, gridSize.z);
+    if(DEBUG) printf("Block settings: x:%d; y:%d; z:%d;\n", blockSize.x, blockSize.y, blockSize.z);
+    #endif
+    
+    //---------> Greedy harmonic sum
     cudaDeviceSetCacheConfig(cudaFuncCachePreferL1);
     cudaDeviceSetSharedMemConfig(cudaSharedMemBankSizeFourByte);
-    call_kernel_PHS_GPU_kernel(gridSize, blockSize, d_input, d_output_SNR, d_output_harmonics, d_MSD, nTimesamples, nSpectra, nHarmonics);
+    call_kernel_greedy_harmonic_sum_GPU_kernel(
+        gridSize,
+        blockSize,
+        d_input,
+        d_output_SNR,
+        d_output_harmonics,
+        d_MSD,
+        nTimesamples,
+        nDMs,
+        nHarmonics,
+        enable_scalloping_loss_removal
+    );
+    
+    return(0);
   }
-
+  
+  int periodicity_presto_harmonic_summing(
+      float *d_input,
+      float *d_output_SNR,
+      ushort *d_output_harmonics,
+      float *d_MSD,
+      int nTimesamples,
+      int nDMs,
+      int nHarmonics,
+      int enable_scalloping_loss_removal
+  ) {
+    //---------> Task specific
+    int nBlocks_x, nBlocks_y;
+    nBlocks_x = (nTimesamples + GHRMS_NTHREADS - 1)/GHRMS_NTHREADS;
+    nBlocks_y = nDMs;
+    dim3 gridSize(nBlocks_x, nBlocks_y, 1);
+    dim3 blockSize(GHRMS_NTHREADS, 1, 1);
+    
+    #ifdef HS_DEBUG
+    if(DEBUG) printf("Data dimensions: %zu x %zu;\n",nDMs, nTimesamples);
+    if(DEBUG) printf("Grid  settings: x:%d; y:%d; z:%d;\n", gridSize.x, gridSize.y, gridSize.z);
+    if(DEBUG) printf("Block settings: x:%d; y:%d; z:%d;\n", blockSize.x, blockSize.y, blockSize.z);
+    #endif
+    
+    //---------> PRESTO harmonic sum
+    cudaDeviceSetCacheConfig(cudaFuncCachePreferL1);
+    cudaDeviceSetSharedMemConfig(cudaSharedMemBankSizeFourByte);
+    call_kernel_presto_harmonic_sum_GPU_kernel(
+        gridSize,
+        blockSize,
+        d_input,
+        d_output_SNR,
+        d_output_harmonics,
+        d_MSD,
+        nTimesamples,
+        nDMs,
+        nHarmonics,
+        enable_scalloping_loss_removal
+    );
+    
+    return(0);
+  }
 } //namespace astroaccelerate

--- a/src/aa_device_harmonic_summing.cu
+++ b/src/aa_device_harmonic_summing.cu
@@ -78,6 +78,49 @@ namespace astroaccelerate {
     return(0);
   }
   
+  int periodicity_presto_plus_harmonic_summing(
+      float *d_input,
+      float *d_output_SNR,
+      ushort *d_output_harmonics,
+      float *d_MSD,
+      int nTimesamples,
+      int nDMs,
+      int nHarmonics,
+      int enable_scalloping_loss_removal
+  ) {
+    //---------> Task specific
+    int nBlocks_x, nBlocks_y;
+    nBlocks_x = (nTimesamples + GHRMS_NTHREADS - 1)/GHRMS_NTHREADS;
+    nBlocks_y = nDMs;
+    dim3 gridSize(nBlocks_x, nBlocks_y, 1);
+    dim3 blockSize(GHRMS_NTHREADS, 1, 1);
+    
+    #ifdef HS_DEBUG
+    if(DEBUG) printf("Data dimensions: %zu x %zu;\n",nDMs, nTimesamples);
+    if(DEBUG) printf("Grid  settings: x:%d; y:%d; z:%d;\n", gridSize.x, gridSize.y, gridSize.z);
+    if(DEBUG) printf("Block settings: x:%d; y:%d; z:%d;\n", blockSize.x, blockSize.y, blockSize.z);
+    #endif
+    
+    //---------> PRESTO harmonic sum
+    cudaDeviceSetCacheConfig(cudaFuncCachePreferL1);
+    cudaDeviceSetSharedMemConfig(cudaSharedMemBankSizeFourByte);
+    call_kernel_presto_plus_harmonic_sum_GPU_kernel(
+        gridSize,
+        blockSize,
+        d_input,
+        d_output_SNR,
+        d_output_harmonics,
+        d_MSD,
+        nTimesamples,
+        nDMs,
+        nHarmonics,
+        enable_scalloping_loss_removal
+    );
+    
+    return(0);
+  }
+  
+  /*
   int periodicity_presto_harmonic_summing(
       float *d_input,
       float *d_output_SNR,
@@ -119,4 +162,6 @@ namespace astroaccelerate {
     
     return(0);
   }
+  */
+  
 } //namespace astroaccelerate

--- a/src/aa_device_harmonic_summing_kernel.cu
+++ b/src/aa_device_harmonic_summing_kernel.cu
@@ -67,8 +67,8 @@ __global__ void greedy_harmonic_sum_GPU_kernel(float *d_maxSNR, ushort *d_maxHar
     int maxHarmonics;
     
     if(threadIdx.x<nHarmonics) {
-        s_MSD[threadIdx.x]      = d_MSD[2*threadIdx.x];
-        s_MSD[32 + threadIdx.x] = d_MSD[2*threadIdx.x + 1];
+        s_MSD[2*threadIdx.x]      = d_MSD[2*threadIdx.x];
+        s_MSD[2*threadIdx.x + 1] = d_MSD[2*threadIdx.x + 1];
     }
     
     __syncthreads();

--- a/src/aa_device_harmonic_summing_kernel.cu
+++ b/src/aa_device_harmonic_summing_kernel.cu
@@ -5,92 +5,294 @@
 
 namespace astroaccelerate {
 
-  __global__ void PHS_GPU_kernel_old(float const* __restrict__ d_input, float *d_output_SNR, ushort *d_output_harmonics, float *d_MSD, int nTimesamples, int nSpectra, int nHarmonics){
-    float signal_mean=d_MSD[0];
-    float signal_sd=d_MSD[1];
-    float HS_value, temp_SNR, SNR;
-    ushort max_SNR_harmonic;
-    int pos;
+__global__ void simple_harmonic_sum_GPU_kernel(float const* __restrict__ d_input, float *d_output_SNR, ushort *d_output_harmonics, float *d_MSD, int nTimesamples, int nSpectra, int nHarmonics){
+  float HS_value, temp_SNR, SNR;
+  ushort max_SNR_harmonic;
+  int pos;
 
-    // reading 0th harmonic, i.e. fundamental frequency
-    pos = blockIdx.x*nSpectra + blockIdx.y*blockDim.x + threadIdx.x;
-    if( (blockIdx.y*blockDim.x + threadIdx.x)<nSpectra ){
-      HS_value = __ldg(&d_input[pos]);
-      SNR = (HS_value - signal_mean)/(signal_sd);
-      max_SNR_harmonic = 0;
-		
-      if(blockIdx.x>0) {
-	for(int f=1; f<nHarmonics; f++){
-	  if( (blockIdx.x + f*blockIdx.x)<nTimesamples ){
-	    pos = (blockIdx.x + f*blockIdx.x)*nSpectra + blockIdx.y*blockDim.x + threadIdx.x;
-	    HS_value = HS_value + __ldg(&d_input[pos]);
-	    temp_SNR = __frsqrt_rn(f+1)*(HS_value - signal_mean*(f+1))/(signal_sd); //assuming white noise 
-	    if(temp_SNR > SNR){
-	      SNR = temp_SNR;
-	      max_SNR_harmonic = f;
-	    }
-	  }
-	}
+  // reading 0th harmonic, i.e. fundamental frequency
+  pos = blockIdx.x*nSpectra + blockIdx.y*blockDim.x + threadIdx.x;
+  if( (blockIdx.y*blockDim.x + threadIdx.x)<nSpectra ){
+    HS_value = __ldg(&d_input[pos]);
+    SNR = (HS_value - __ldg(&d_MSD[0]))/(__ldg(&d_MSD[1]));
+    max_SNR_harmonic = 0;
+    
+    if(blockIdx.x>0) {
+      for(int f=1; f<nHarmonics; f++) {
+        if( (blockIdx.x + f*blockIdx.x)<nTimesamples ) {
+          pos = (blockIdx.x + f*blockIdx.x)*nSpectra + blockIdx.y*blockDim.x + threadIdx.x;
+          HS_value = HS_value + __ldg(&d_input[pos]);
+          temp_SNR = (HS_value - __ldg(&d_MSD[f*2]))/(__ldg(&d_MSD[2*f+1])); //assuming white noise 
+          if(temp_SNR > SNR) {
+            SNR = temp_SNR;
+            max_SNR_harmonic = f;
+          }
+        }
       }
-		
-      pos = blockIdx.x*nSpectra + blockIdx.y*blockDim.x + threadIdx.x;
-      d_output_SNR[pos] = SNR;
-      d_output_harmonics[pos] = max_SNR_harmonic;
+    }
+    
+    pos = blockIdx.x*nSpectra + blockIdx.y*blockDim.x + threadIdx.x;
+    d_output_SNR[pos] = SNR;
+    d_output_harmonics[pos] = max_SNR_harmonic;
+  }
+}
+
+__inline__ __device__ float remove_scalloping_loss(float Xm2, float Xm1, float X0, float Xp1, float Xp2){
+    return(X0 + (1.88494/2.0)*(Xm1 + Xp1) + (0.88494/2.0)*(Xm2 + Xp2));
+}
+
+template<class const_params>
+__inline__ __device__ void get_frequency_bins(float *down, float *step, float const* __restrict__ d_input, int pos){
+    if(const_params::remove_scalloping_loss) {
+        float Xm2 = d_input[pos - 2];
+        float Xm1 = d_input[pos - 1];
+        float X0  = d_input[pos + 0];
+        float Xp1 = d_input[pos + 1];
+        float Xp2 = d_input[pos + 2];
+        float Xp3 = d_input[pos + 3];
+        (*down) = remove_scalloping_loss(Xm2, Xm1, X0, Xp1, Xp2);
+        (*step) = remove_scalloping_loss(Xm1, X0, Xp1, Xp2, Xp3);
+    }
+    else {
+        (*down) = d_input[pos];
+        (*step) = d_input[pos + 1];
+    }
+}
+
+template<class const_params>
+__global__ void greedy_harmonic_sum_GPU_kernel(float *d_maxSNR, ushort *d_maxHarmonics, float const* __restrict__ d_input, float const* __restrict__ d_MSD, int nTimesamples, int nDMs, int nHarmonics){
+    __shared__ float s_MSD[64];
+    float SNR;
+    float partial_sum, maxSNR;
+    int maxHarmonics;
+    
+    if(threadIdx.x<nHarmonics) {
+        s_MSD[threadIdx.x]      = d_MSD[2*threadIdx.x];
+        s_MSD[32 + threadIdx.x] = d_MSD[2*threadIdx.x + 1];
+    }
+    
+    __syncthreads();
+    
+    int data_shift=0;
+    float data_down = 0, data_step = 0;
+    int pos = GHRMS_NTHREADS*blockIdx.x + threadIdx.x;
+    if( pos > 1 && pos + 3 < nTimesamples) {
+        int block_pos = blockIdx.y*nTimesamples + pos;
+        get_frequency_bins<const_params>(&data_down, &data_step, d_input, block_pos);
+    }
+    if( data_step > data_down ) {
+        data_shift++;
+        partial_sum = data_step;
+    }
+    else {
+        partial_sum = data_down;
+    }
+    maxSNR = fdividef( (partial_sum - s_MSD[0]), s_MSD[1]);
+    maxHarmonics = 0;
+    
+    for(int h=1; h<nHarmonics; h++){
+        int pos = (h+1)*(GHRMS_NTHREADS*blockIdx.x + threadIdx.x) + data_shift;
+        float data_down = 0, data_step = 0;
+        if( pos > 1 && pos + 3 < nTimesamples) {
+            int block_pos = blockIdx.y*nTimesamples + pos;
+            get_frequency_bins<const_params>(&data_down, &data_step, d_input, block_pos);
+        }
+        
+        if( data_step > data_down ) {
+            data_shift++;
+            partial_sum = partial_sum + data_step;
+        }
+        else {
+            partial_sum = partial_sum + data_down;
+        }
+        
+        SNR = fdividef( (partial_sum - s_MSD[2*h]), s_MSD[2*h+1] );
+        if( SNR > maxSNR ) {
+            maxSNR = SNR;
+            maxHarmonics = h;
+        }
+    }
+    
+    pos = GHRMS_NTHREADS*blockIdx.x + threadIdx.x;
+    if(pos < nTimesamples) {
+        d_maxSNR[blockIdx.y*nTimesamples + pos] = maxSNR;
+        d_maxHarmonics[blockIdx.y*nTimesamples + pos] = (ushort) maxHarmonics;
+    }
+}
+
+
+template<class const_params>
+__inline__ __device__ void get_frequency_bin_value(float *frequency_bin, float const* __restrict__ data, int pos){
+    if(const_params::remove_scalloping_loss){
+        float Xm2 = data[pos - 2];
+        float Xm1 = data[pos - 1];
+        float X0  = data[pos];
+        float Xp1 = data[pos + 1];
+        float Xp2 = data[pos + 2];
+        (*frequency_bin) = X0 + (1.88494/2.0)*(Xm1 + Xp1) + (0.88494/2.0)*(Xm2 + Xp2);
+    }
+    else {
+        (*frequency_bin) = data[pos];
+    }
+}
+
+
+template<class const_params>
+__global__ void presto_harmonic_sum_GPU_kernel(float *d_maxSNR, ushort *d_maxHarmonics, float const* __restrict__ d_input, float const* __restrict__ d_MSD, int nTimesamples, int nDMs, int nHarmonics){
+    __shared__ float s_MSD[64];
+    float SNR;
+    float partial_sum, maxSNR, frequency_bin, fundamental;
+    int maxHarmonics, pos;
+    
+    if(threadIdx.x<nHarmonics) {
+        s_MSD[2*threadIdx.x]   = d_MSD[2*threadIdx.x];
+        s_MSD[2*threadIdx.x+1] = d_MSD[2*threadIdx.x+1];
+    }
+    
+    __syncthreads();
+    
+    partial_sum = 0;
+    frequency_bin = 0;
+    fundamental = 0;
+    pos = GHRMS_NTHREADS*blockIdx.x + threadIdx.x;
+    if( (pos > 1) && (pos + 2) < nTimesamples ) {
+        int block_pos = blockIdx.y*nTimesamples + pos;
+        get_frequency_bin_value<const_params>(&fundamental, d_input, block_pos);
+    }
+    partial_sum = fundamental;
+    maxSNR = fdividef( (partial_sum - s_MSD[0]), s_MSD[1]);
+    maxHarmonics = 0;
+    
+    if( pos > 1 && (pos + 2) < nTimesamples ) {
+        for(int i = 1; i < nHarmonics; i++){ //i + 1 = num. of harmonic added;
+            partial_sum = fundamental;
+            double fundamental_fraction = ((double) pos)/((double) (i + 1));
+            for(int f= 1; f<=i; f++){
+                int new_pos = (int) ( ( ((double) f)*fundamental_fraction ) + 0.5 );
+                int block_pos = blockIdx.y*nTimesamples + new_pos;
+                frequency_bin = 0;
+                if( new_pos > 1 && (new_pos + 2) < nTimesamples ) {
+                    get_frequency_bin_value<const_params>(&frequency_bin, d_input, block_pos);
+                }
+                partial_sum = partial_sum + frequency_bin;
+            }
+            SNR = fdividef( (partial_sum - s_MSD[2*i]), s_MSD[2*i + 1]);
+            if(SNR>maxSNR) {
+                maxSNR = SNR;
+                maxHarmonics = i-1;
+            }
+        }
+    }
+    //----------------------------------------------
+    
+    __syncthreads();
+    
+    pos = GHRMS_NTHREADS*blockIdx.x + threadIdx.x;
+    if( pos < nTimesamples ){
+        int block_pos = blockIdx.y*nTimesamples + pos;
+        d_maxSNR[block_pos] = maxSNR;
+        d_maxHarmonics[block_pos] = maxHarmonics;
+    }
+}
+
+
+
+
+
+//-------------------------------------------------------------------
+//------------------------------- Callers ---------------------------
+//-------------------------------------------------------------------
+
+  /** \brief Kernel wrapper function for simple_harmonic_sum_GPU_kernel kernel function. */
+  void call_kernel_simple_harmonic_sum_GPU_kernel(
+      const dim3 &grid_size,
+      const dim3 &block_size,
+      float const *const d_input,
+      float *const d_output_SNR,
+      ushort *const d_output_harmonics,
+      float *const d_MSD,
+      const int &nTimesamples,
+      const int &nSpectra,
+      const int &nHarmonics
+  ) {
+    simple_harmonic_sum_GPU_kernel<<<grid_size, block_size>>>(d_input, d_output_SNR, d_output_harmonics, d_MSD, nTimesamples, nSpectra, nHarmonics);
+  }
+
+  /** \brief Kernel wrapper function for call_kernel_greedy_harmonic_sum_GPU_kernel kernel function. */
+  void call_kernel_greedy_harmonic_sum_GPU_kernel(
+      const dim3 &grid_size,
+      const dim3 &block_size,
+      float const *const d_input,
+      float *const d_output_SNR,
+      ushort *const d_output_harmonics,
+      float *const d_MSD,
+      const int &nTimesamples,
+      const int &nDMs,
+      const int &nHarmonics,
+      bool enable_scalloping_loss_removal
+  ) {
+    if(enable_scalloping_loss_removal) {
+      greedy_harmonic_sum_GPU_kernel<HRMS_remove_scalloping_loss><<<grid_size, block_size>>>(
+          d_output_SNR,
+          d_output_harmonics,
+          d_input,
+          d_MSD,
+          nTimesamples,
+          nDMs,
+          nHarmonics
+      );
+    }
+    else {
+      greedy_harmonic_sum_GPU_kernel<HRMS_normal><<<grid_size, block_size>>>(
+          d_output_SNR,
+          d_output_harmonics,
+          d_input,
+          d_MSD,
+          nTimesamples,
+          nDMs,
+          nHarmonics
+      );
     }
   }
 
-
-  __global__ void PHS_GPU_kernel(float const* __restrict__ d_input, float *d_output_SNR, ushort *d_output_harmonics, float *d_MSD, int nTimesamples, int nSpectra, int nHarmonics){
-    //extern __shared__ float s_MSD[];
-    float HS_value, temp_SNR, SNR;
-    ushort max_SNR_harmonic;
-    int pos;
-
-    //int itemp = (2*nHarmonics)/blockDim.x;
-    //for(int f=0; f<itemp; f++){
-    //	pos = f*blockDim.x + threadIdx.x;
-    //	if(pos<nHarmonics) s_MSD[pos] = d_MSD[pos];
-    //}
-
-    // reading 0th harmonic, i.e. fundamental frequency
-    pos = blockIdx.x*nSpectra + blockIdx.y*blockDim.x + threadIdx.x;
-    if( (blockIdx.y*blockDim.x + threadIdx.x)<nSpectra ){
-      HS_value = __ldg(&d_input[pos]);
-      SNR = (HS_value - __ldg(&d_MSD[0]))/(__ldg(&d_MSD[1]));
-      max_SNR_harmonic = 0;
-		
-      if(blockIdx.x>0) {
-	for(int f=1; f<nHarmonics; f++) {
-	  if( (blockIdx.x + f*blockIdx.x)<nTimesamples ) {
-	    pos = (blockIdx.x + f*blockIdx.x)*nSpectra + blockIdx.y*blockDim.x + threadIdx.x;
-	    HS_value = HS_value + __ldg(&d_input[pos]);
-	    temp_SNR = (HS_value - __ldg(&d_MSD[f*2]))/(__ldg(&d_MSD[2*f+1])); //assuming white noise 
-	    if(temp_SNR > SNR) {
-	      SNR = temp_SNR;
-	      max_SNR_harmonic = f;
-	    }
-	  }
-	}
-      }
-		
-      pos = blockIdx.x*nSpectra + blockIdx.y*blockDim.x + threadIdx.x;
-      d_output_SNR[pos] = SNR;
-      d_output_harmonics[pos] = max_SNR_harmonic;
+  /** \brief Kernel wrapper function for presto_harmonic_sum_GPU_kernel kernel function. */
+  void call_kernel_presto_harmonic_sum_GPU_kernel(
+      const dim3 &grid_size,
+      const dim3 &block_size,
+      float const *const d_input,
+      float *const d_output_SNR,
+      ushort *const d_output_harmonics,
+      float *const d_MSD,
+      const int &nTimesamples,
+      const int &nDMs,
+      const int &nHarmonics,
+      bool enable_scalloping_loss_removal
+  ) {
+    if(enable_scalloping_loss_removal) {
+      presto_harmonic_sum_GPU_kernel<HRMS_remove_scalloping_loss><<<grid_size, block_size>>>(
+          d_output_SNR,
+          d_output_harmonics,
+          d_input,
+          d_MSD,
+          nTimesamples,
+          nDMs,
+          nHarmonics
+      );
+    }
+    else {
+      presto_harmonic_sum_GPU_kernel<HRMS_normal><<<grid_size, block_size>>>(
+          d_output_SNR,
+          d_output_harmonics,
+          d_input,
+          d_MSD,
+          nTimesamples,
+          nDMs,
+          nHarmonics
+      );
     }
   }
-
-  /** \brief Kernel wrapper function for PHS_GPU_kernel_old kernel function. */
-  void call_kernel_PHS_GPU_kernel_old(const dim3 &grid_size, const dim3 &block_size,
-				      float const *const d_input, float *const d_output_SNR, ushort *const d_output_harmonics,
-				      float *const d_MSD, const int &nTimesamples, const int &nSpectra, const int &nHarmonics) {
-    PHS_GPU_kernel_old<<<grid_size, block_size>>>(d_input, d_output_SNR, d_output_harmonics, d_MSD, nTimesamples, nSpectra, nHarmonics);
-  }
-
-  /** \brief Kernel wrapper function for PHS_GPU_kernel kernel function. */
-  void call_kernel_PHS_GPU_kernel(const dim3 &grid_size, const dim3 &block_size,
-				  float const *const d_input, float *const d_output_SNR, ushort *const d_output_harmonics,
-				  float *const d_MSD, const int &nTimesamples, const int &nSpectra, const int &nHarmonics) {
-    PHS_GPU_kernel<<<grid_size, block_size>>>(d_input, d_output_SNR, d_output_harmonics, d_MSD, nTimesamples, nSpectra, nHarmonics);
-  }
-
 } //namespace astroaccelerate
+
+
+
+

--- a/src/aa_device_harmonic_summing_kernel.cu
+++ b/src/aa_device_harmonic_summing_kernel.cu
@@ -256,7 +256,7 @@ __global__ void presto_harmonic_sum_GPU_kernel(float *d_maxSNR, ushort *d_maxHar
   }
 
   /** \brief Kernel wrapper function for presto_harmonic_sum_GPU_kernel kernel function. */
-  void call_kernel_presto_harmonic_sum_GPU_kernel(
+  void call_kernel_presto_plus_harmonic_sum_GPU_kernel(
       const dim3 &grid_size,
       const dim3 &block_size,
       float const *const d_input,

--- a/src/aa_device_peak_find.cu
+++ b/src/aa_device_peak_find.cu
@@ -50,64 +50,88 @@ namespace astroaccelerate {
     call_kernel_dilate_peak_find_for_fdas(gridSize, blockDim, d_ffdot_plane, d_peak_list, d_MSD, nTimesamples, nDMs, 0, threshold, max_peak_size, gmem_peak_pos, DM_trial);
   }
 
-  void Peak_find_for_periodicity_search_old(float *d_input_SNR, ushort *d_input_harmonics, float *d_peak_list, int nDMs, int nTimesamples, float threshold, int max_peak_size, int *gmem_peak_pos, float *d_MSD, int DM_shift, int inBin){
-    dim3 blockDim(32, 32, 1);
-    dim3 gridSize(1 + ((nTimesamples-1)/blockDim.x), 1 + ((nDMs-1)/blockDim.y), 1);
-	
-    call_kernel_dilate_peak_find_for_periods_old(gridSize, blockDim, d_input_SNR, d_input_harmonics, d_peak_list, nTimesamples, nDMs, 0, threshold, max_peak_size, gmem_peak_pos, d_MSD, DM_shift, inBin);
+  int Peak_find_for_periodicity_search(float *d_input_SNR, ushort *d_input_harmonics, float *d_peak_list, int nTimesamples, int nDMs, float threshold, int max_peak_size, int *gmem_peak_pos, float *d_MSD, int DM_shift, int inBin, bool transposed_data){
+      // nTimesamples = secondary_size
+      // nDMs = primary_size
+      //---------> Nvidia stuff
+      // find maximum values for maximum grid sizes in x and y
+      cudaDeviceProp deviceProp;
+      cudaGetDeviceProperties(&deviceProp, CARD);
+      size_t max_x = deviceProp.maxGridSize[0], max_y = deviceProp.maxGridSize[1];
+     
+      //---------> Task specific
+      int primary_size = 0, secondary_size = 0;
+      std::vector<size_t> secondary_size_per_chunk;
+      int nBlocks_p, nBlocks_s, nRepeats;
+      size_t sec_per_chunk, sec_tail;
+      dim3 blockDim(32, 32, 1);
+      
+      if(transposed_data){
+          primary_size = nDMs;
+          secondary_size = nTimesamples;
+          // number of thread-blocks required for the task
+          nBlocks_p = 1 + ((primary_size-1)/blockDim.x); 
+          if((size_t) nBlocks_p > max_x) {printf("Too many DM trials!\n"); return(1);}
+          nBlocks_s = 1 + ((secondary_size-1)/blockDim.y);
+          
+          // number of kernel launches required for the task
+          nRepeats = ceil( (float) ((float) nBlocks_s)/((float) max_y));
+          sec_per_chunk = (int) (secondary_size/nRepeats);
+          sec_tail = secondary_size - sec_per_chunk*(nRepeats-1);
+          
+          // creating vector with y dim processed by each kernel launch
+          for(int f=0; f<(nRepeats-1); f++){
+              secondary_size_per_chunk.push_back(sec_per_chunk);
+          }
+          secondary_size_per_chunk.push_back(sec_tail);
+      }
+      else {
+          primary_size = nTimesamples;
+          secondary_size = nDMs;
+          // number of thread-blocks required for the task
+          nBlocks_p = 1 + ((primary_size-1)/blockDim.x); 
+          if((size_t) nBlocks_p > max_x) {printf("Too many samples trials!\n"); return(1);}
+          nBlocks_s = 1 + ((secondary_size-1)/blockDim.y);
+          
+          // number of kernel launches required for the task
+          nRepeats = ceil( (float) ((float) nBlocks_s)/((float) max_y));
+          sec_per_chunk = (int) (secondary_size/nRepeats);
+          sec_tail = secondary_size - sec_per_chunk*(nRepeats-1);
+          
+          // creating vector with y dim processed by each kernel launch
+          for(int f=0; f<(nRepeats-1); f++){
+              secondary_size_per_chunk.push_back(sec_per_chunk);
+          }
+          secondary_size_per_chunk.push_back(sec_tail);
+      }
+     
+      #ifdef PEAK_FIND_DEBUG
+      printf("Primary:%d; Secondary:%d\n", primary_size, secondary_size);
+      printf("gridSize: [%d; %d; %d]\n", nBlocks_p, nBlocks_s, 1);
+      printf("blockSize: [%d; %d; %d]\n", blockDim.x, blockDim.y, blockDim.z);
+      printf("nRepeats: %d; sec_per_chunk: %zu; sec_tail: %zu;\n", nRepeats, sec_per_chunk, sec_tail);
+      printf("Secondary dimensions per chunk: ");
+      for(size_t f=0; f<secondary_size_per_chunk.size(); f++) printf("%zu ", secondary_size_per_chunk[f]); printf("\n");	
+      #endif
+      
+      // launching GPU kernels
+      size_t shift = 0;
+      for(int f=0; f<(int) secondary_size_per_chunk.size(); f++){
+        nBlocks_s = 1 + ((secondary_size_per_chunk[f]-1)/blockDim.y);
+        if(transposed_data){
+            dim3 gridSize(nBlocks_p, nBlocks_s, 1);
+            call_kernel_peak_find_for_periodicity_transposed(gridSize, blockDim, &d_input_SNR[shift*primary_size], d_input_harmonics, d_peak_list, primary_size, secondary_size, 0, threshold, max_peak_size, gmem_peak_pos, d_MSD, DM_shift, inBin);
+        }
+        else {
+            dim3 gridSize(nBlocks_p, nBlocks_s, 1);
+            call_kernel_peak_find_for_periodicity_normal(gridSize, blockDim, &d_input_SNR[shift*primary_size], d_input_harmonics, d_peak_list, primary_size, secondary_size, 0, threshold, max_peak_size, gmem_peak_pos, d_MSD, DM_shift, inBin);
+        }
+        shift = shift + secondary_size_per_chunk[f];
+      }
+      return(0);
   }
-
-  void Peak_find_for_periodicity_search(float *d_input_SNR, ushort *d_input_harmonics, float *d_peak_list, int secondary_size, int primary_size, float threshold, int max_peak_size, int *gmem_peak_pos, float *d_MSD, int DM_shift, int inBin){
-    // nDMs = secondary_size
-    // nTimesamples = primary_size
-    //---------> Nvidia stuff
-    // find maximum values for maximum grid sizes in x and y
-    cudaDeviceProp deviceProp;
-    cudaGetDeviceProperties(&deviceProp, CARD);
-    size_t max_x = deviceProp.maxGridSize[0], max_y = deviceProp.maxGridSize[1];
-	
-    //---------> Task specific
-    int nBlocks_p, nBlocks_s, nRepeats;
-    size_t sec_per_chunk, sec_tail;
-    dim3 blockDim(32, 32, 1);
-	
-    // number of thread-blocks required for the task
-    nBlocks_p = 1 + ((primary_size-1)/blockDim.x);
-    if((size_t) nBlocks_p > max_x) {printf("Too many DM trials!\n"); exit(1);}
-    nBlocks_s = 1 + ((secondary_size-1)/blockDim.y);
-	
-    // number of kernel launches required for the task
-    nRepeats = ceil( (float) ((float) nBlocks_s)/((float) max_y));
-    sec_per_chunk = (int) (secondary_size/nRepeats);
-    sec_tail = secondary_size - sec_per_chunk*(nRepeats-1);
-	
-    // creating vector with y dim processed by each kernel launch
-    std::vector<size_t> secondary_size_per_chunk;
-    for(int f=0; f<(nRepeats-1); f++){
-      secondary_size_per_chunk.push_back(sec_per_chunk);
-    }
-    secondary_size_per_chunk.push_back(sec_tail);
-	
-#ifdef PEAK_FIND_DEBUG
-    printf("Primary:%d; Secondary:%d\n", primary_size, secondary_size);
-    printf("gridSize: [%d; %d; %d]\n", nBlocks_p, nBlocks_s, 1);
-    printf("blockSize: [%d; %d; %d]\n", blockDim.x, blockDim.y, blockDim.z);
-    printf("nRepeats: %d; sec_per_chunk: %zu; sec_tail: %zu;\n", nRepeats, sec_per_chunk, sec_tail);
-    printf("Secondary dimensions per chunk: ");
-    for(size_t f=0; f<secondary_size_per_chunk.size(); f++) printf("%zu ", secondary_size_per_chunk[f]); printf("\n");	
-#endif
-	
-    // launching GPU kernels
-    size_t shift = 0;
-    for(int f=0; f<(int) secondary_size_per_chunk.size(); f++){
-      nBlocks_s = 1 + ((secondary_size_per_chunk[f]-1)/blockDim.y);
-      dim3 gridSize(nBlocks_p, nBlocks_s, 1);
-	
-      call_kernel_dilate_peak_find_for_periods(gridSize, blockDim, &d_input_SNR[shift*primary_size], d_input_harmonics, d_peak_list, primary_size, secondary_size, 0, threshold, max_peak_size, gmem_peak_pos, d_MSD, DM_shift, inBin);
-		
-      shift = shift + secondary_size_per_chunk[f];
-    }
-	
-  }
-
+  
+  
+  
+  
 } //namespace astroaccelerate

--- a/src/aa_device_peak_find_kernel.cu
+++ b/src/aa_device_peak_find_kernel.cu
@@ -232,10 +232,10 @@ __global__ void peak_find_list2(const float *d_input, const int width, const int
       if(SNR > threshold) {
 	list_pos=atomicAdd(gmem_pos, 1);
 	if(list_pos<max_peak_size){
-	  d_peak_list[4*list_pos]   = idxY;
-	  d_peak_list[4*list_pos+1] = idxX;
-	  d_peak_list[4*list_pos+2] = my_value;
-	  d_peak_list[4*list_pos+3] = DM_trial;
+	  d_peak_list[4*list_pos]   = idxY; // frequency
+	  d_peak_list[4*list_pos+1] = idxX; // acceleration
+	  d_peak_list[4*list_pos+2] = my_value; // SNR
+	  d_peak_list[4*list_pos+3] = DM_trial; //  DM_trial
 	}
       }
     }
@@ -336,95 +336,50 @@ __global__ void peak_find_list2(const float *d_input, const int width, const int
   }
 
 
-
-
-
-
-  __global__ void dilate_peak_find_for_periods(const float *d_input, ushort* d_input_taps, float *d_peak_list, const int width, const int height, const int offset, const float threshold, int max_peak_size, int *gmem_pos, float const* __restrict__ d_MSD, int DM_shift, int DIT_value) {
-    int idxX = blockDim.x * blockIdx.x + threadIdx.x;
-    int idxY = blockDim.y * blockIdx.y + threadIdx.y;
-    if (idxX >= width-offset) return;
-    if (idxY >= height) return;
-
-    float dilated_value = 0.0f;
-    float my_value = 0.0f;
-    unsigned short peak = 0u;
-    int list_pos;
-    //handle boundary conditions - top edge
-    if (idxY == 0) {
-      //Special case for width of 1
-      if (width == 1) {
-	my_value = dilated_value = d_input[0];
-      }
-      //Top left corner case
-      else if (idxX == 0) {
-	float4 block = load_block_2x2(d_input, width);
-	dilated_value = dilate4(block);
-	my_value = block.x;
-      } 
-      //Top right corner case
-      else if (idxX == (width-offset-1)) {
-	float4 block = load_block_2x2(d_input+width-offset-2, width);
-	dilated_value = dilate4(block);
-	my_value = block.y;
-      } else {
-	float3x3 block = load_block_top(d_input, idxX, idxY, width);
-	dilated_value = dilate3x3_top(block);
-	my_value = block.y2;
-      }
-      //bottom edge
-    } else if (idxY == height-1) {
-      //Special case for width of 1
-      if (width == 1) {
-	my_value = dilated_value = d_input[width*(height-1)];
-      }
-      //Bottom left corner
-      else if (idxX == 0) {
-	float4 block = load_block_2x2(d_input+width*(height-2), width);
-	dilated_value = dilate4(block);
-	my_value = block.z;
-      }
-      //Bottom right corner
-      else if (idxX == (width-offset-1)) {
-	float4 block = load_block_2x2(d_input+width*(height-2)+width-offset-2, width);
-	dilated_value = dilate4(block);
-	my_value = block.w;
-      } else {
-	float3x3 block = load_block_bottom(d_input, idxX, idxY, width);        
-	dilated_value = dilate3x3_bottom(block);
-	my_value = block.y2;
-      }
-      //Left edge
-    } else if (idxX == 0) {
-      float3x3 block = load_block_left(d_input, idxX, idxY, width);        
-      dilated_value = dilate3x3_left(block);
-      my_value = block.y2;
+ //TODO: Improve performance of the peak find by using shared memory atomics and then storing data to device memory?
+  __global__ void peak_find_for_periodicity_normal_kernel(const float *d_input, ushort* d_input_taps, float *d_peak_list, const int nTimesamples, const int nDMs, const int offset, const float threshold, int max_peak_size, int *gmem_pos, float const* __restrict__ d_MSD, int DM_shift, int DIT_value) {
+    int idxX = blockDim.x*blockIdx.x + threadIdx.x;
+    int idxY = blockDim.y*blockIdx.y + threadIdx.y;
+    if (idxX >= nTimesamples - offset) return;
+    if (idxY >= nDMs) return;
     
-      //right edge
-    } else if (idxX == (width-offset-1)) {
-      float3x3 block = load_block_right(d_input, idxX, idxY, width);        
-      dilated_value = dilate3x3_right(block);
-      my_value = block.y2;
-
-    } else {
-      float3x3 block = load_block(d_input, idxX, idxY, width);
-      dilated_value = dilate3x3(block);
-      my_value = block.y2;
-    }
-    peak = is_peak( my_value, dilated_value, threshold);
+    int list_pos;
+    float my_value = 0.0f;
+    unsigned short peak = does_thread_contains_peak(&my_value, d_input, idxX, idxY, nTimesamples, nDMs, threshold, offset);
+    
     if(peak==1){
       list_pos=atomicAdd(gmem_pos, 1);
       if(list_pos<max_peak_size){
-	d_peak_list[4*list_pos]   = idxX + DM_shift; // DM coordinate (y)
-	d_peak_list[4*list_pos+1] = idxY/DIT_value; // frequency coordinate (x)
-	int hrms = (int) d_input_taps[idxY*width+idxX];
-	d_peak_list[4*list_pos+3] = hrms; // width of the boxcar
-	d_peak_list[4*list_pos+2] = my_value*__ldg(&d_MSD[2*hrms+1]) + __ldg(&d_MSD[2*hrms]); // SNR value
-			
+        d_peak_list[4*list_pos]   = idxY + DM_shift; // DM coordinate (y)
+        d_peak_list[4*list_pos+1] = idxX/DIT_value; // frequency coordinate (x)
+        int hrms = (int) d_input_taps[idxY*nTimesamples+idxX];
+        d_peak_list[4*list_pos+3] = hrms; // width of the boxcar
+        d_peak_list[4*list_pos+2] = my_value*__ldg(&d_MSD[2*hrms+1]) + __ldg(&d_MSD[2*hrms]); // SNR value
       }
     }
-	
-    //d_output[idxY*width+idxX] = peak;
+  }
+
+
+  __global__ void peak_find_for_periodicity_transposed_kernel(const float *d_input, ushort* d_input_taps, float *d_peak_list, const int width, const int height, const int offset, const float threshold, int max_peak_size, int *gmem_pos, float const* __restrict__ d_MSD, int DM_shift, int DIT_value) {
+    int idxX = blockDim.x*blockIdx.x + threadIdx.x;
+    int idxY = blockDim.y*blockIdx.y + threadIdx.y;
+    if (idxX >= width-offset) return;
+    if (idxY >= height) return;
+    
+    int list_pos;
+    float my_value = 0.0f;
+    unsigned short peak = does_thread_contains_peak(&my_value, d_input, idxX, idxY, width, height, threshold, offset);
+    
+    if(peak==1){
+      list_pos=atomicAdd(gmem_pos, 1);
+      if(list_pos<max_peak_size){
+        d_peak_list[4*list_pos]   = idxX + DM_shift; // DM coordinate (y)
+        d_peak_list[4*list_pos+1] = idxY/DIT_value; // frequency coordinate (x)
+        int hrms = (int) d_input_taps[idxY*width+idxX];
+        d_peak_list[4*list_pos+3] = hrms; // width of the boxcar
+        d_peak_list[4*list_pos+2] = my_value*__ldg(&d_MSD[2*hrms+1]) + __ldg(&d_MSD[2*hrms]); // SNR value
+      }
+    }
   }
 
 
@@ -469,12 +424,10 @@ __global__ void gpu_Filter_peaks_kernel(unsigned int *d_new_peak_list_DM, unsign
                         s_data_ts[threadIdx.x]  = 0; //f4temp.y; // Time
                         s_data_snr[threadIdx.x] = -1000; //f4temp.z; // SNR
 		}
-//		if(blockIdx.x==0 && threadIdx.x==0) printf("point: [%d;%d;%lf]\n",  s_data_dm[threadIdx.x], s_data_ts[threadIdx.x], s_data_snr[threadIdx.x]);
 		
 		
 		pos = PPF_DPB*f + threadIdx.x + PPF_NTHREADS;
 		if(pos < nElements){
-//			f4temp = __ldg(&d_peak_list[PPF_DPB*f + threadIdx.x + (PPF_DPB>>1)]);
 			s_data_dm[threadIdx.x + PPF_NTHREADS ] = d_peak_list_DM[pos]; //f4temp.x; // DM
 			s_data_ts[threadIdx.x + PPF_NTHREADS ] = d_peak_list_TS[pos]; //f4temp.y; // Time
 			s_data_snr[threadIdx.x + PPF_NTHREADS] = d_peak_list_SNR[pos]; //f4temp.z; // SNR
@@ -489,23 +442,17 @@ __global__ void gpu_Filter_peaks_kernel(unsigned int *d_new_peak_list_DM, unsign
 
 		elements_pos = blockIdx.x*PPF_PEAKS_PER_BLOCK;
 		for(int p=0; p<PPF_PEAKS_PER_BLOCK; p++){
-//			if (blockIdx.x == 0) printf("%d %d\n", p, s_flag[p]);
 			if((s_flag[p]) && ((elements_pos + p) < nElements)){
-				//pos = elements_pos+p;
-				//if(pos<nElements){
 					d   = d_peak_list_DM[elements_pos+p]; // DM
 					s   = d_peak_list_TS[elements_pos+p]; // Time
 					snr = d_peak_list_SNR[elements_pos+p]; // SNR
 					
 					// first element
-//					if(blockIdx.x==0) printf("s_data: %lf, snr: %lf, pos: %d\n", s_data_snr[threadIdx.x], snr, p);
 					if( (s_data_snr[threadIdx.x] >= snr)){
 						fs = ((float)s_data_dm[threadIdx.x] - (float)d);
 						fd = ((float)s_data_ts[threadIdx.x] - (float)s);
 						distance = (fd*fd + fs*fs);
-//						if(blockIdx.x==0) printf("%d - %d = %d; %d - %d = %d\n",s_data_dm[threadIdx.x], d, fs, s_data_ts[threadIdx.x], s, fd, distance);
 						if( (distance < (float)max_distance) && (distance!=0) ){
-//							if(blockIdx.x==0) printf("distance: %d %lf %lf %lf %d %d;\n", p, distance, fs, fd, s, d);
 							s_flag[p]=0;
 						}
 					}
@@ -515,13 +462,10 @@ __global__ void gpu_Filter_peaks_kernel(unsigned int *d_new_peak_list_DM, unsign
 						fs = ((float)s_data_dm[threadIdx.x + PPF_NTHREADS] - (float)d);
 						fd = ((float)s_data_ts[threadIdx.x + PPF_NTHREADS] - (float)s);
 						distance = (fd*fd + fs*fs);
-//						if(blockIdx.x==0) printf("%d - %d = %d; %d - %d = %d\n",s_data_dm[threadIdx.x], d, fs, s_data_ts[threadIdx.x], s, fd, distance);
 						if( (distance < (float)max_distance) && (distance!=0)){
 							s_flag[p]=0;
-//							if(blockIdx.x==0) printf("xdistance: %d %lf %lf %lf %d %d;\n", p, distance, fs, fd, s, d);
 						}
 					}
-				//}
 			}
 		} // for p
 		
@@ -585,17 +529,69 @@ __global__ void gpu_Filter_peaks_kernel(unsigned int *d_new_peak_list_DM, unsign
   }
 
   /** \brief Kernel wrapper function for _dilate_peak_find_for_periods kernel function. */
-  void call_kernel_dilate_peak_find_for_periods(const dim3 &grid_size, const dim3 &block_size,
-						float *const d_input, ushort *const d_input_taps,
-						float *const d_peak_list, const int &width,
-						const int &height, const int &offset, const float &threshold,
-						const int &max_peak_size,
-						int *const gmem_pos, float const *const d_MSD, const int &DM_shift, const int &DIT_value) {
-    dilate_peak_find_for_periods<<<grid_size, block_size>>>(d_input, d_input_taps,
-							    d_peak_list, width,
-							    height, offset, threshold,
-							    max_peak_size,
-							    gmem_pos, d_MSD, DM_shift, DIT_value);
+  void call_kernel_peak_find_for_periodicity_normal(
+      const dim3 &grid_size,
+      const dim3 &block_size,
+      float *const d_input,
+      ushort *const d_input_taps,
+      float *const d_peak_list,
+      const int &nTimesamples,
+      const int &nDMs,
+      const int &offset,
+      const float &threshold,
+      const int &max_peak_size,
+      int *const gmem_pos,
+      float const *const d_MSD,
+      const int &DM_shift,
+      const int &DIT_value
+  ) {
+    peak_find_for_periodicity_normal_kernel<<<grid_size, block_size>>>(
+        d_input,
+        d_input_taps,
+        d_peak_list,
+        nTimesamples,
+        nDMs,
+        offset,
+        threshold,
+        max_peak_size,
+        gmem_pos,
+        d_MSD,
+        DM_shift,
+        DIT_value
+    );
+  }
+
+  /** \brief Kernel wrapper function for _dilate_peak_find_for_periods kernel function. */
+  void call_kernel_peak_find_for_periodicity_transposed(
+      const dim3 &grid_size,
+      const dim3 &block_size,
+      float *const d_input,
+      ushort *const d_input_taps,
+      float *const d_peak_list,
+      const int &width,
+      const int &height,
+      const int &offset,
+      const float &threshold,
+      const int &max_peak_size,
+      int *const gmem_pos,
+      float const *const d_MSD,
+      const int &DM_shift,
+      const int &DIT_value
+  ) {
+    peak_find_for_periodicity_transposed_kernel<<<grid_size, block_size>>>(
+        d_input,
+        d_input_taps,
+        d_peak_list,
+        width,
+        height,
+        offset,
+        threshold,
+        max_peak_size,
+        gmem_pos,
+        d_MSD,
+        DM_shift,
+        DIT_value
+    );
   }
 
 	void call_kernel_peak_find_list(const dim3 &grid_size, const dim3 &block_size, float *const d_input, const int width, const int height, const float &threshold, int *const gmem_pos, const int &shift, const int &DIT_value, ushort *const d_input_taps, const int &max_peak_size, unsigned int *const d_peak_list_DM, unsigned int *const d_peak_list_TS, float *const d_peak_list_SNR, unsigned int *const d_peak_list_BW){

--- a/src/aa_device_periods.cu
+++ b/src/aa_device_periods.cu
@@ -1169,7 +1169,7 @@ namespace astroaccelerate {
 
 
   /** \brief Function that performs a GPU periodicity search. */
-  void GPU_periodicity(int nRanges, int nsamp, int max_ndms, int processed, float sigma_cutoff, float ***output_buffer, int const*const ndms, int *inBin, float *dm_low, float *dm_high, float *dm_step, float tsamp, int nHarmonics, bool candidate_algorithm, bool enable_msd_baseline_noise, float OR_sigma_multiplier) {
+  void GPU_periodicity(int nRanges, int processed, float sigma_cutoff, float ***output_buffer, int const*const ndms, int *inBin, float *dm_low, float *dm_high, float *dm_step, float tsamp, int nHarmonics, bool candidate_algorithm, bool enable_msd_baseline_noise, float OR_sigma_multiplier) {
     // processed = maximum number of time-samples through out all ranges
     // nTimesamples = number of time-samples in given range 'i'
 	

--- a/src/aa_device_periods.cu
+++ b/src/aa_device_periods.cu
@@ -24,13 +24,15 @@
 #include "aa_device_threshold.hpp"
 #include "aa_gpu_timer.hpp"
 #include "aa_host_utilities.hpp"
+#include "aa_timelog.hpp"
 #include "presto_funcs.hpp"
 #include "presto.hpp"
+
 
 namespace astroaccelerate {
 
   // define to see debug info
-  #define GPU_PERIODICITY_SEARCH_DEBUG
+  //#define GPU_PERIODICITY_SEARCH_DEBUG
   
   // define to perform CPU spectral whitening debug
   //#define CPU_SPECTRAL_WHITENING_DEBUG
@@ -105,7 +107,7 @@ namespace astroaccelerate {
 
     /** \brief Method to print member variables of an instance. */
     void print(void) {
-      printf("dedispersion range: %f--%f:%f inBin:%d; nTimesamples:%d; nDMs:%d; sampling time:%f\n", dm_low, dm_high, dm_step, inBin, nTimesamples, nDMs, sampling_time);
+      LOG(log_level::debug, "   dedispersion range:" + std::to_string(dm_low) + "--" + std::to_string(dm_high) + ":" + std::to_string(dm_step) + "; Binning:" + std::to_string(inBin) + "; nTimesamples:" + std::to_string(nTimesamples) + "; nDMs:" + std::to_string(nDMs) + ";");
     }
   };
 
@@ -126,8 +128,13 @@ namespace astroaccelerate {
 
     /** \brief Method for printing member variable information. */
     void print() {
-      printf("De-dispersion ranges:\n");
+      LOG(log_level::debug, "--------------------------");
+      LOG(log_level::debug, "> De-dispersion plan used:");
+      LOG(log_level::debug, "   sampling time: " + std::to_string(sampling_time));
+      LOG(log_level::debug, "   processed time samples by de-dispersion: " + std::to_string(nProcessedTimesamples));
+      LOG(log_level::debug, "   maximum number of DM trials: " + std::to_string(max_nDMs));
       for(int f=0; f<(int)DD_range.size(); f++) DD_range[f].print();
+	  LOG(log_level::debug, "--------------------------");
     }
   };
 
@@ -163,9 +170,8 @@ namespace astroaccelerate {
     }
 
     /** \brief Method for printing member variable data for an instance. */
-    void print() {
-      printf("      Batch: nDMs:%d; nTimesamples:%d; DM shift:%d;\n", nDMs_per_batch, nTimesamples, DM_shift);
-      MSD_conf.print();
+    void print(int id) {
+      LOG(log_level::debug, "-> Batch:" + std::to_string(id) + "; nDMs:" + std::to_string(nDMs_per_batch) + "; nTimesamples:" + std::to_string(nTimesamples) + "; DM shift:" + std::to_string(DM_shift) + ";");
     }
   };
 
@@ -191,16 +197,14 @@ namespace astroaccelerate {
       nRepeats = range.nDMs/max_nDMs_in_range;
       nRest = range.nDMs - nRepeats*max_nDMs_in_range;
       for(int f=0; f<nRepeats; f++) {
-	Periodicity_Batch batch(max_nDMs_in_range, f*max_nDMs_in_range, range, total_MSD_blocks+address_shift);
-	batches.push_back(batch);
-	total_MSD_blocks = total_MSD_blocks + batch.MSD_conf.nBlocks_total;
-	//batches.push_back( *(new Periodicity_Batch(max_nDMs_in_range, f*max_nDMs_in_range, range)) );
+        Periodicity_Batch batch(max_nDMs_in_range, f*max_nDMs_in_range, range, total_MSD_blocks+address_shift);
+        batches.push_back(batch);
+        total_MSD_blocks = total_MSD_blocks + batch.MSD_conf.nBlocks_total;
       }
       if(nRest>0) {
-	Periodicity_Batch batch(nRest, nRepeats*max_nDMs_in_range, range, total_MSD_blocks+address_shift);
-	batches.push_back(batch);
-	total_MSD_blocks = total_MSD_blocks + batch.MSD_conf.nBlocks_total;
-	//batches.push_back( *(new Periodicity_Batch(nRest, nRepeats*max_nDMs_in_range, range)) );
+        Periodicity_Batch batch(nRest, nRepeats*max_nDMs_in_range, range, total_MSD_blocks+address_shift);
+        batches.push_back(batch);
+        total_MSD_blocks = total_MSD_blocks + batch.MSD_conf.nBlocks_total;
       }
     }
 
@@ -210,8 +214,6 @@ namespace astroaccelerate {
       // Finding nearest lower power of two (because of FFT algorithm)
       int nearest = (int)floorf(log2f((float)range.nTimesamples));
       range.nTimesamples = (int) powf(2.0, (float) nearest);
-      // This should not be necessary
-      //range.nTimesamples = range.nTimesamples/range.inBin;
     }
 
     Periodicity_Range(Dedispersion_Range t_range, int max_nDMs_in_memory, int t_rangeid, int address_shift) {
@@ -224,20 +226,27 @@ namespace astroaccelerate {
 
     /** \brief Destructor for Periodicity_Range. */
     ~Periodicity_Range() {
-      //for(int f=0; f<(int)batches.size(); f++) delete batches[f];
       batches.clear();
     }
 
     /** \brief Method for printing member variable data of an instance. */
     void print(void) {
       int size = (int)batches.size();
-      printf("  De-dispersion range: %f--%f:%f inBin:%d; nTimesamples:%d; nDMs:%d;\n", range.dm_low, range.dm_high, range.dm_step, range.inBin, range.nTimesamples, range.nDMs);
-      if(size>1) printf("     De-dispersion range will be processed in %d batches each containing %d DM trials with tail of %d DM trials\n", size, batches[0].nDMs_per_batch, batches[size-1].nDMs_per_batch);
-      else printf("     Periodicity search will run 1 batch containing %d DM trials.\n", batches[0].nDMs_per_batch);
-      printf("     Total number of MSD blocks is %d which is %0.3f MB\n", total_MSD_blocks, (total_MSD_blocks*3.0*sizeof(float))/(1024.0*1024.0));
-      printf("--------- Batches ----------\n");
-      for(int f=0; f<(int)batches.size(); f++) batches[f].print();
-      printf("\n");
+	  int batchDM_0 = batches[0].nDMs_per_batch;
+      //printf("  De-dispersion range: %f--%f:%f inBin:%d; nTimesamples:%d; nDMs:%d;\n", range.dm_low, range.dm_high, range.dm_step, range.inBin, range.nTimesamples, range.nDMs);
+      LOG(log_level::notice, "-> De-dispersion range:" + std::to_string(range.dm_low) + "--" + std::to_string(range.dm_high) + ":" + std::to_string(range.dm_step) + "; Binning:" + std::to_string(range.inBin) + "; nTimesamples:" + std::to_string(range.nTimesamples) + "; nDMs:" + std::to_string(range.nDMs) + ";");
+      if(size>1) {
+        int batchDM_last = batches[size-1].nDMs_per_batch;
+        LOG(log_level::notice, "-> De-dispersion range will be processed in " + std::to_string(size) + " batches each containing " + std::to_string(batchDM_0) + " DM trials with tail of " + std::to_string(batchDM_last) + " DM trials");
+      }
+      else LOG(log_level::notice, "-> Periodicity search will run 1 batch containing " + std::to_string(batchDM_0) + " DM trials.");
+      float MSD_block_mem = (total_MSD_blocks*MSD_PARTIAL_SIZE*sizeof(float))/(1024.0*1024.0);
+      LOG(log_level::debug, "-> Total number of MSD blocks is " + std::to_string(total_MSD_blocks) + " which is " + std::to_string(MSD_block_mem) + "MB");
+      #ifdef GPU_PERIODICITY_SEARCH_DEBUG
+          printf("--------- Batches ----------\n");
+          for(int f=0; f<(int)batches.size(); f++) batches[f].print();
+          printf("\n");
+      #endif
     }
   };
 
@@ -255,9 +264,9 @@ namespace astroaccelerate {
 	
     void print(void) {
       for(int f=0; f<(int) Prange.size(); f++){
-	printf("  ->Periodicity range: %d\n", f);
-	Prange[f].print();
-      }		
+        printf("  ->Periodicity range: %d\n", f);
+        Prange[f].print();
+      }
     }
   };
 
@@ -298,8 +307,8 @@ namespace astroaccelerate {
       printf("input_plane_size:     %zu floating point numbers = %0.2f MB;\n", input_plane_size, ((float) input_plane_size*sizeof(float))/(1024.0*1024.0));
       printf("cuFFT_workarea_size:  %zu = %0.2f MB;\n", cuFFT_workarea_size, (float) cuFFT_workarea_size/(1024.0*1024.0));
       for(int f=0; f<(int) inBin_group.size(); f++){
-	printf("inBin group: %d\n", f);
-	inBin_group[f].print();
+        printf("inBin group: %d\n", f);
+        inBin_group[f].print();
       }
     }
   };
@@ -459,7 +468,7 @@ namespace astroaccelerate {
       if ( cudaSuccess != cudaMalloc((void**) &gmem_interbin_peak_pos, 1*sizeof(int)) )  printf("Periodicity Allocation error! gmem_interbin_peak_pos\n");
 		
       if ( cudaSuccess != cudaMalloc((void**) &d_MSD, sizeof(float)*MSD_interpolated_size*2)) {printf("Periodicity Allocation error! d_MSD\n");}
-      printf("DEBUG--------------------------------- MSD_DIT_size %d -------- MSD_PARTIAL_SIZE %d\n", MSD_DIT_size, MSD_PARTIAL_SIZE);
+      
       if ( cudaSuccess != cudaMalloc((void**) &d_previous_partials, sizeof(float)*MSD_DIT_size*MSD_PARTIAL_SIZE)) {printf("Periodicity Allocation error! d_previous_partials\n");}
       if ( cudaSuccess != cudaMalloc((void**) &d_all_blocks, sizeof(float)*P_plan->max_total_MSD_blocks*MSD_PARTIAL_SIZE)) {printf("Periodicity Allocation error! d_MSD\n");}
 		
@@ -467,13 +476,11 @@ namespace astroaccelerate {
     }
 	
     void Reset_MSD(){
-      printf("  Resetting MSD variables\n");
       cudaMemset(d_MSD, 0, MSD_interpolated_size*2*sizeof(float));
       cudaMemset(d_previous_partials, 0, MSD_DIT_size*MSD_PARTIAL_SIZE*sizeof(float));
     }
 	
     void Reset_Candidate_List(){
-      printf("         Resetting candidate lists\n");
       cudaMemset(gmem_power_peak_pos, 0, sizeof(int));
       cudaMemset(gmem_interbin_peak_pos, 0, sizeof(int));
     }
@@ -560,7 +567,7 @@ namespace astroaccelerate {
     size_t max_nDMs_in_memory, itemp;
 
     size_t memory_per_DM = ((max_nTimesamples+2)*(multiple_float*sizeof(float) + multiple_ushort*sizeof(ushort)));
-    printf("   Memory required for one DM is %0.3f MB available memory is %0.3f MB %zu\n", memory_per_DM/(1024.0*1024.0), (memory_available*0.95)/(1024.0*1024.0), memory_available);
+    LOG(log_level::debug, "   Memory required for one DM trial is " + std::to_string((float) memory_per_DM/(1024.0*1024.0)) + "MB");
     max_nDMs_in_memory = (memory_available*0.98)/((max_nTimesamples+2)*(multiple_float*sizeof(float) + multiple_ushort*sizeof(ushort))); // 1 for real input real, 2 for complex output, 2 for complex cuFFT, 1 for peaks + 1 ushort
     if((max_nDMs+PHS_NTHREADS)<max_nDMs_in_memory) { //if we can fit all DM trials from largest range into memory then we need to find nearest higher multiple of PHS_NTHREADS
       itemp = (int)(max_nDMs/PHS_NTHREADS);
@@ -571,6 +578,40 @@ namespace astroaccelerate {
     max_nDMs_in_memory = itemp*PHS_NTHREADS;
 
     return(max_nDMs_in_memory);
+  }
+  
+  
+  
+  size_t Get_max_cuFFT_workarea_size(AA_Periodicity_Plan *P_plan){
+	  // This whole unfortunate function is necessary because as of CUDA11 cufftMakePlan1d may return size of the cuFFT workarea larger (up to 2x) for some input values of nDMs (number of FFTs calculated). This value is larger then the value returned for some other larger value of nDMs thus we cannot rely on getting size of the cuFFT workarea just for largest number of FFT calculated.
+      cufftHandle plan_input;
+      cufftResult cufft_error;
+      size_t max_cuFFT_workarea_size = 0;
+	  size_t temporary_cuFFT_workarea_size = 0;
+	  
+	  for(int p=0; p<(int) P_plan->inBin_group.size(); p++) {
+		  for(int r=0; r<(int) P_plan->inBin_group[p].Prange.size(); r++) {
+			  for(int b=0; b<(int)P_plan->inBin_group[p].Prange[r].batches.size(); b++) {
+				  //int    inbin        = P_plan.inBin_group[p].Prange[r].inBin;
+				  size_t nTimesamples = P_plan->inBin_group[p].Prange[r].batches[b].nTimesamples;
+				  size_t nDMs         = P_plan->inBin_group[p].Prange[r].batches[b].nDMs_per_batch;
+				  
+				  cufftCreate(&plan_input);
+				  cufftSetAutoAllocation(plan_input, false);
+				  cufft_error = cufftMakePlan1d(plan_input, nTimesamples, CUFFT_R2C, nDMs, &temporary_cuFFT_workarea_size);
+				  if (CUFFT_SUCCESS != cufft_error){
+					  printf("CUFFT error: %d", cufft_error);
+				  }
+				  cufftDestroy(plan_input);
+				  
+				  if(temporary_cuFFT_workarea_size > max_cuFFT_workarea_size) {
+					  max_cuFFT_workarea_size = temporary_cuFFT_workarea_size;
+				  }
+			  }
+		  }
+	  }
+	  
+      return(max_cuFFT_workarea_size);
   }
 
   void Create_Periodicity_Plan(AA_Periodicity_Plan *P_plan, Dedispersion_Plan *DD_plan, size_t max_nDMs_in_memory) {
@@ -611,69 +652,63 @@ namespace astroaccelerate {
     P_plan->max_nTimesamples     = max_nTimesamples;
   }
 
-  void Find_Periodicity_Plan(int *max_nDMs_in_memory, AA_Periodicity_Plan *P_plan, Dedispersion_Plan *DD_plan, size_t memory_available){
-    size_t memory_allocated, memory_for_data;
-    size_t input_plane_size;
-	
-    int nearest = (int)floorf(log2f((float) DD_plan->nProcessedTimesamples));
-    size_t t_max_nTimesamples = (size_t) powf(2.0, (float) nearest);
-    size_t t_max_nDMs = (size_t) DD_plan->max_nDMs;
-    size_t t_max_nDMs_in_memory;
-	
-    float multiple_float  = 5.5;
-    float multiple_ushort = 2.0; 
-	
-    printf("--------------------------------- FINDING PERIODICITY PLAN -------------------------------\n");
-    memory_for_data = memory_available;
-    do {
-      printf("   Memory_for_data: %zu = %0.3f MB\n", memory_for_data, (float) memory_for_data/(1024.0*1024.0));
-      t_max_nDMs_in_memory = Calculate_max_nDMs_in_memory(t_max_nTimesamples, t_max_nDMs, memory_for_data, multiple_float, multiple_ushort);
-      if(t_max_nDMs_in_memory==0) {
-        printf("Error not enough memory for periodicity search!");
-        exit(1);
-      }
-      input_plane_size = (t_max_nTimesamples+2)*t_max_nDMs_in_memory;
-      memory_allocated = input_plane_size*multiple_float*sizeof(float) + multiple_ushort*input_plane_size*sizeof(ushort);
-      printf("   Maximum number of DM trials which fit into memory is %zu;\n   Maximum time trials %zu;\n   Input plane size: %0.2f MB;\n", (size_t) t_max_nDMs_in_memory, t_max_nTimesamples, (((float) input_plane_size*sizeof(float))/(1024.0*1024.0)) );
-		
-
-      Create_Periodicity_Plan(P_plan, DD_plan, t_max_nDMs_in_memory);
-      //max_total_blocks = Find_Max_total_blocks(P_plan);
-      //------------------- Additional memory for MSD --------------------------------------
-      int nDecimations = ((int) floorf(log2f((float)P_plan->nHarmonics))) + 2;
-      size_t additional_data_size = P_plan->max_total_MSD_blocks*MSD_RESULTS_SIZE*sizeof(float) + nDecimations*2*MSD_RESULTS_SIZE*sizeof(float) + P_plan->nHarmonics*2*sizeof(float) + 2*sizeof(int);
-      memory_allocated = memory_allocated + additional_data_size;
-      printf("   Memory available for the component: %0.3f MB (%zu bytes)\n", (float) memory_available/(1024.0*1024.0), memory_available);
-      printf("   Memory allocated by the component: %0.3f MB (%zu bytes)\n", (float) memory_allocated/(1024.0*1024.0), memory_allocated);
-
-      if(t_max_nTimesamples!=(size_t)P_plan->max_nTimesamples) printf("Interesting!\n");
-		
-      if(memory_allocated>memory_available) {
-        printf("Not enough memory for given configuration of periodicity plan. Calculating new plan...\n");
-        memory_for_data = memory_for_data - additional_data_size;
-        P_plan->clear();
-      }
-    } while(memory_allocated > memory_available);
-    printf("------------------------------------------------------------------------------------------\n");
-	
-    P_plan->max_nDMs_in_memory = (int) t_max_nDMs_in_memory;
-    P_plan->input_plane_size = (P_plan->max_nTimesamples+2)*t_max_nDMs_in_memory;
-    //----------------------------------------------
-    //----------> Exact calculation of cuFFT workarea size
-    cufftHandle plan_input;
-    cufftResult cufft_error;
-    size_t cuFFT_workarea_size;
-    cufftCreate(&plan_input);
-    cufftSetAutoAllocation(plan_input, false);
-    cufft_error = cufftMakePlan1d(plan_input, P_plan->max_nTimesamples, CUFFT_R2C, t_max_nDMs_in_memory, &cuFFT_workarea_size);
-    if (CUFFT_SUCCESS != cufft_error){
-      printf("CUFFT error: %d", cufft_error);
-    }
-    printf("Workarea size:%0.2f MB\n", (float) cuFFT_workarea_size/(1024.0*1024.0));
-    cufftDestroy(plan_input);
-    P_plan->cuFFT_workarea_size = cuFFT_workarea_size;
-    //----------------------------------------------<
-    *max_nDMs_in_memory = (int) t_max_nDMs_in_memory;
+  bool Find_Periodicity_Plan(int *max_nDMs_in_memory, AA_Periodicity_Plan *P_plan, Dedispersion_Plan *DD_plan, size_t memory_available){
+      size_t memory_allocated, memory_for_data;
+      size_t input_plane_size;
+      
+      int nearest = (int) floorf(log2f((float) DD_plan->nProcessedTimesamples));
+      size_t t_max_nTimesamples = (size_t) powf(2.0, (float) nearest);
+      size_t t_max_nDMs = (size_t) DD_plan->max_nDMs;
+      size_t t_max_nDMs_in_memory = 0;
+      size_t t_max_cuFFT_workarea_size = 0;
+      
+      
+      float multiple_float  = 5.5;
+      float multiple_ushort = 2.0; 
+      
+      
+      LOG(log_level::debug, "> FINDING PERIODICITY PLAN:");
+      memory_for_data = memory_available;
+      do {
+          //printf("   Memory_for_data: %zu = %0.3f MB\n", memory_for_data, (float) memory_for_data/(1024.0*1024.0));
+          LOG(log_level::debug, "   Memory available: " + std::to_string(memory_for_data) + " = " + std::to_string((float) memory_for_data/(1024.0*1024.0)) + "MB");
+          t_max_nDMs_in_memory = Calculate_max_nDMs_in_memory(t_max_nTimesamples, t_max_nDMs, memory_for_data, multiple_float, multiple_ushort);
+          if(t_max_nDMs_in_memory==0) {
+              LOG(log_level::error, "Error not enough memory for periodicity search!");
+              return(false);
+          }
+          input_plane_size = (t_max_nTimesamples+2)*t_max_nDMs_in_memory;
+          memory_allocated = input_plane_size*multiple_float*sizeof(float) + multiple_ushort*input_plane_size*sizeof(ushort);
+          LOG(log_level::debug, "   Maximum number of DM trials which fit into memory is: " +  std::to_string(t_max_nDMs_in_memory));
+          LOG(log_level::debug, "   Maximum time trials: " +  std::to_string(t_max_nTimesamples));
+          LOG(log_level::debug, "   Input plane size: " +  std::to_string((((float) input_plane_size*sizeof(float))/(1024.0*1024.0))) + " MB;")
+          
+          
+          Create_Periodicity_Plan(P_plan, DD_plan, t_max_nDMs_in_memory);
+          t_max_cuFFT_workarea_size = Get_max_cuFFT_workarea_size(P_plan);
+          
+          //-------- Additional memory for MSD ------
+          int nDecimations = ((int) floorf(log2f((float)P_plan->nHarmonics))) + 2;
+          size_t additional_data_size = P_plan->max_total_MSD_blocks*MSD_PARTIAL_SIZE*sizeof(float) + nDecimations*2*MSD_RESULTS_SIZE*sizeof(float) + P_plan->nHarmonics*2*sizeof(float) + 2*sizeof(int);
+          memory_allocated = memory_allocated + additional_data_size;
+          LOG(log_level::debug, "   Memory available for the component: " + std::to_string((float) memory_available/(1024.0*1024.0)) + "MB (" + std::to_string(memory_available) + " bytes)");
+          LOG(log_level::debug, "   Memory allocated by the component: " + std::to_string((float) memory_allocated/(1024.0*1024.0)) + "MB (" + std::to_string(memory_allocated) + " bytes)");
+          
+          if(memory_allocated>memory_available) {
+              LOG(log_level::warning, "--> Not enough memory for given configuration of periodicity plan. Calculating new plan...");
+              memory_for_data = memory_for_data - additional_data_size;
+              P_plan->clear();
+          }
+      } while(memory_allocated > memory_available);
+      
+      P_plan->max_nDMs_in_memory = (int) t_max_nDMs_in_memory;
+      P_plan->input_plane_size = (P_plan->max_nTimesamples+2)*t_max_nDMs_in_memory;
+      P_plan->cuFFT_workarea_size = t_max_cuFFT_workarea_size;
+      LOG(log_level::debug, "   Workarea size: " + std::to_string((float) t_max_cuFFT_workarea_size/(1024.0*1024.0)) + "MB");
+      
+      *max_nDMs_in_memory = (int) t_max_nDMs_in_memory;
+      LOG(log_level::debug, "--------------------------");
+      return(true);
   }
 
   void Copy_data_for_periodicity_search(float *d_one_A, float **dedispersed_data, Periodicity_Batch *batch){ //TODO add "cudaStream_t stream1"
@@ -763,8 +798,7 @@ namespace astroaccelerate {
 		
       FILE *fp_out;
       if (( fp_out = fopen(final_filename, "wb") ) == NULL) {
-        fprintf(stderr, "Error opening output file!\n");
-        exit(0);
+        LOG(log_level::error, "Error opening output file!");
       }
       fwrite(h_export, nTimesamples*chunk_size[i]*sizeof(float), 3, fp_out);
       fclose(fp_out);
@@ -776,15 +810,21 @@ namespace astroaccelerate {
     delete [] h_export;
   }
 
+void checkCudaErrors( cudaError_t CUDA_error){
+ if(CUDA_error != cudaSuccess) {
+  printf("CUDA error: %d\n", CUDA_error);
+ }
+}
   /**
    * \brief Performs a periodicity search on the GPU.
    * \todo Clarify the difference between Periodicity_search and GPU_periodicity.
    **/
   void Periodicity_search(GPU_Memory_for_Periodicity_Search *gmem, aa_periodicity_strategy per_param, double *compute_time, size_t input_plane_size, Periodicity_Range *Prange, Periodicity_Batch *batch, std::vector<int> *h_boxcar_widths, int harmonic_sum_algorithm, bool enable_scalloping_loss_removal){
-	bool transposed_data = true;
-	if(harmonic_sum_algorithm != 0){
-		transposed_data = false;
-	}
+    bool transposed_data = true;
+    if(harmonic_sum_algorithm != 0){
+        transposed_data = false;
+    }
+    TimeLog time_log;
 	
     int local_max_list_size = (input_plane_size)/4;
 	
@@ -813,7 +853,7 @@ namespace astroaccelerate {
 	}
 	
     int t_nTimesamples      = batch->nTimesamples;
-	int t_nTSamplesFFT      = (t_nTimesamples>>1) + 1;
+    int t_nTSamplesFFT      = (t_nTimesamples>>1) + 1;
     int t_nDMs_per_batch    = batch->nDMs_per_batch;
     int t_DM_shift          = batch->DM_shift;
     int t_inBin             = Prange->range.inBin;
@@ -824,27 +864,30 @@ namespace astroaccelerate {
     timer.Start();
     cufftHandle plan_input;
     cufftResult cufft_error;
-	
+    
     size_t cuFFT_workarea_size;
-	
-    cufftCreate(&plan_input);
+    
+    cufft_error = cufftCreate(&plan_input);
+    if (CUFFT_SUCCESS != cufft_error) printf("CUFFT error: %d", cufft_error);
     cufftSetAutoAllocation(plan_input, false);
 	
     cufft_error = cufftMakePlan1d(plan_input, t_nTimesamples, CUFFT_R2C, t_nDMs_per_batch, &cuFFT_workarea_size);
-    if (CUFFT_SUCCESS != cufft_error){
-      printf("CUFFT error: %d", cufft_error);
-    }
-    cufftSetWorkArea(plan_input, gmem->cuFFT_workarea);
+    if (CUFFT_SUCCESS != cufft_error) printf("CUFFT error: %d", cufft_error);
+	
+    cufft_error = cufftSetWorkArea(plan_input, gmem->cuFFT_workarea);
+    if (CUFFT_SUCCESS != cufft_error) printf("CUFFT error: %d", cufft_error);
 
     cufft_error = cufftExecR2C(plan_input, (cufftReal *)d_dedispersed_data, (cufftComplex *)d_FFT_complex_output);
     if ( cufft_error != CUFFT_SUCCESS) printf("CUFFT error: %d\n", cufft_error);
 	
-    cufftDestroy(plan_input);
+    cufft_error = cufftDestroy(plan_input);
+    if ( cufft_error != CUFFT_SUCCESS) printf("CUFFT error: %d\n", cufft_error);
 
     timer.Stop();
-    printf("         -> cuFFT took %f ms\n", timer.Elapsed());
+    time_log.adding("PSR","cuFFT",timer.Elapsed());
     (*compute_time) = (*compute_time) + timer.Elapsed();
     //---------<
+	
 	
 	#ifdef CPU_SPECTRAL_WHITENING_DEBUG
 	float t_dm_step         = Prange->range.dm_step;
@@ -987,7 +1030,7 @@ namespace astroaccelerate {
     cudaStream_t stream; stream = NULL;
     spectrum_whitening_SGP2((float2 *) d_FFT_complex_output, t_nTSamplesFFT, t_nDMs_per_batch, true, stream);
     timer.Stop();
-    printf("         -> Performing spectrum whitening took %f ms\n", timer.Elapsed());
+    time_log.adding("PSR","spectrum whitening",timer.Elapsed());
     (*compute_time) = (*compute_time) + timer.Elapsed();
     //---------<
 	
@@ -1015,7 +1058,7 @@ namespace astroaccelerate {
     //simple_power_and_interbin( (float2 *) d_two_B, d_half_C, d_one_A, nTimesamples, t_nDMs_per_batch);
     simple_power_and_interbin( (float2 *) d_FFT_complex_output, d_frequency_power, d_frequency_interbin, t_nTimesamples, t_nDMs_per_batch);
     timer.Stop();
-    printf("         -> Calculation of powers and interbining took %f ms\n", timer.Elapsed());
+    time_log.adding("PSR","power spectrum",timer.Elapsed());
     (*compute_time) = (*compute_time) + timer.Elapsed();
     //---------<
 	
@@ -1050,10 +1093,11 @@ namespace astroaccelerate {
 
     double total_time, dit_time, MSD_time;
     MSD_plane_profile(gmem->d_MSD, d_frequency_power, gmem->d_previous_partials, d_MSD_workarea, true, (t_nTimesamples>>1), t_nDMs_per_batch, h_boxcar_widths, 0, 0, 0, per_param.sigma_constant(), per_param.enable_msd_baseline_noise(), perform_continuous, &total_time, &dit_time, &MSD_time);
-    printf("    MSD time: Total: %f ms; DIT: %f ms; MSD: %f ms;\n", total_time, dit_time, MSD_time);
+    //printf("    MSD time: Total: %f ms; DIT: %f ms; MSD: %f ms;\n", total_time, dit_time, MSD_time);
     
     timer.Stop();
-    printf("         -> MSD took %f ms\n", timer.Elapsed());
+    //printf("         -> MSD took %f ms\n", timer.Elapsed());
+    time_log.adding("PSR","MSD",timer.Elapsed());
     (*compute_time) = (*compute_time) + timer.Elapsed();
     //---------<
     
@@ -1084,7 +1128,8 @@ namespace astroaccelerate {
         //---------<
     }
     timer.Stop();
-    printf("         -> harmonic summing took %f ms\n", timer.Elapsed());
+    //printf("         -> harmonic summing took %f ms\n", timer.Elapsed());
+    time_log.adding("PSR","harmonic sum",timer.Elapsed());
     (*compute_time) = (*compute_time) + timer.Elapsed();
     //---------<
 	
@@ -1115,7 +1160,6 @@ namespace astroaccelerate {
     //---------> Peak finding
     timer.Start();
     if(per_param.candidate_algorithm()){
-		printf("Doing Thresholding...\n");
         //-------------- Thresholding
         if(harmonic_sum_algorithm == 0){
             Threshold_for_periodicity_transposed(d_power_SNR, gmem->d_power_harmonics, d_power_list, gmem->gmem_power_peak_pos, gmem->d_MSD, per_param.sigma_cutoff(), t_nDMs_per_batch, (t_nTimesamples>>1), t_DM_shift, t_inBin, local_max_list_size);
@@ -1134,7 +1178,8 @@ namespace astroaccelerate {
         //-------------- Peak finding
     }
     timer.Stop();
-    printf("         -> Peak finding took %f ms\n", timer.Elapsed());
+    //printf("         -> Peak finding took %f ms\n", timer.Elapsed());
+    time_log.adding("PSR","candidates",timer.Elapsed());
     (*compute_time) = (*compute_time) + timer.Elapsed();
     //---------<
 	
@@ -1144,8 +1189,7 @@ namespace astroaccelerate {
   void Export_Data_To_File(std::vector<Candidate_List> candidates, const char *filename) {
     FILE *fp_out;
     if((fp_out = fopen(filename, "wb")) == NULL) {
-      fprintf(stderr, "Error opening output file!\n");
-      exit(0);
+      LOG(log_level::error, "Error opening output file!\n");
     }
 
     for(int f=0; f<(int) candidates.size(); f++) {
@@ -1172,13 +1216,15 @@ namespace astroaccelerate {
   void GPU_periodicity(int nRanges, int processed, float sigma_cutoff, float ***output_buffer, int const*const ndms, int *inBin, float *dm_low, float *dm_high, float *dm_step, float tsamp, int nHarmonics, bool candidate_algorithm, bool enable_msd_baseline_noise, float OR_sigma_multiplier) {
     // processed = maximum number of time-samples through out all ranges
     // nTimesamples = number of time-samples in given range 'i'
-	
-    printf("\n");
-    printf("------------ STARTING PERIODICITY SEARCH ------------\n\n");
+    
+    TimeLog time_log;
+    
+    LOG(log_level::notice, "------------ STARTING PERIODICITY SEARCH ------------");
+
     // Creating periodicity parameters object (temporary, it should be moved elsewhere)
     aa_periodicity_plan per_param_plan(sigma_cutoff, OR_sigma_multiplier, nHarmonics, 0, candidate_algorithm, enable_msd_baseline_noise); // \warning The periodicity plan uses a hardcoded number (this also used to be the case for the (now deprecated) Periodicity_parameters class.
     aa_periodicity_strategy per_param(per_param_plan);
-    per_param.print_parameters();
+    per_param.print_info(per_param);
 	
     std::vector<int> h_boxcar_widths; h_boxcar_widths.resize(nHarmonics); 
     for(int f=0; f<nHarmonics; f++) h_boxcar_widths[f]=f+1;
@@ -1186,43 +1232,33 @@ namespace astroaccelerate {
     // Creating DDrange vector (temporary, it should be moved elsewhere)
     Dedispersion_Plan DD_plan;
     Create_DD_plan(&DD_plan, nRanges, dm_low, dm_high, dm_step, inBin, processed, ndms, tsamp);
-	
-    printf("--------------------------\n");
     DD_plan.print();
-    printf("--------------------------\n");
-	
+    
     // Determining available memory (temporary, it should be moved elsewhere)
     size_t memory_available,total_mem;
     cudaMemGetInfo(&memory_available,&total_mem);
-    printf("   Memory available:%0.3f MB \n", ((float) memory_available)/(1024.0*1024.0) );
 	
 	
     //----------------------------------------------------------------------------
     //----------- Finding Periodicity plan
+    bool plan_finished;
     int max_nDMs_in_memory;
     AA_Periodicity_Plan P_plan;
     P_plan.nHarmonics = nHarmonics;
-    Find_Periodicity_Plan(&max_nDMs_in_memory, &P_plan, &DD_plan, memory_available);
+    plan_finished = Find_Periodicity_Plan(&max_nDMs_in_memory, &P_plan, &DD_plan, memory_available);
+    if(plan_finished == false) return;
+    
     size_t input_plane_size = P_plan.input_plane_size;
-    P_plan.print();
-    printf("\n");
-	
-    printf("--------------------------------- GPU ALLOCATIONS -------------------------------\n");
-    //-----------------------------------------------------------------------------
-    //-----------------------------------------------------------------------------
+    #ifdef GPU_PERIODICITY_SEARCH_DEBUG
+        P_plan.print();
+    #endif
+    
     //--------> Allocation of GPU memory
     GPU_Memory_for_Periodicity_Search GPU_memory;
-	
     GPU_memory.Allocate(&P_plan);
 	
     float h_MSD[P_plan.nHarmonics*2];
     //----------------------------<
-    //-----------------------------------------------------------------------------
-    //-----------------------------------------------------------------------------
-    printf("---------------------------------------------------------------------------------\n");
-    printf("\n");
-	
-    //checkCudaErrors(cudaGetLastError());
 	
     // Timing
     double Total_periodicity_time = 0, Total_calc_time = 0, calc_time_per_range = 0, Total_copy_time = 0, copy_time_per_range = 0;
@@ -1230,12 +1266,10 @@ namespace astroaccelerate {
 	
     periodicity_timer.Start();
 	
-    printf("--------------------------------- PERIODICITY START -------------------------------\n");
+    LOG(log_level::notice, "------ CONFIGURATION OF PERIODICITY SEARCH DONE -----");
     //---------------------------------------------------------------
     //---------------------------------------------------------------
     for(int p=0; p<(int) P_plan.inBin_group.size(); p++) {
-      printf("--------------------------------------------------\n");
-      printf("inBin range: %d\n", p);
       std::vector<Candidate_List> PowerCandidates;
       std::vector<Candidate_List> InterbinCandidates;
 
@@ -1243,20 +1277,20 @@ namespace astroaccelerate {
 		
 
       for(int r=0; r<(int) P_plan.inBin_group[p].Prange.size(); r++) {
-        printf("  Prange: %d\n", r);
         P_plan.inBin_group[p].Prange[r].print();
         
         for(int b=0; b<(int)P_plan.inBin_group[p].Prange[r].batches.size(); b++) {
-          printf("      Batch: %d\n", b);
-          P_plan.inBin_group[p].Prange[r].batches[b].print();
+          P_plan.inBin_group[p].Prange[r].batches[b].print(b);
 	
           GPU_memory.Reset_Candidate_List();
+		  
+		  checkCudaErrors(cudaGetLastError());
 	
           //---------> Copy input data to the device
           timer.Start();
           Copy_data_for_periodicity_search(GPU_memory.d_one_A, output_buffer[P_plan.inBin_group[p].Prange[r].rangeid], &P_plan.inBin_group[p].Prange[r].batches[b]);
           timer.Stop();
-          printf("         => Copy of data to device took %f ms\n", timer.Elapsed() );
+          time_log.adding("PSR","Host-To-Device",timer.Elapsed());
           copy_time_per_range = copy_time_per_range + timer.Elapsed();
           //---------<
 
@@ -1264,7 +1298,7 @@ namespace astroaccelerate {
           // greedy harmonic sum 1
           // presto harmonic sum 2
           int harmonic_sum_algorithm = 1;
-		  bool enable_scalloping_loss_removal = false;
+          bool enable_scalloping_loss_removal = true;
           
           //---------> Periodicity search
           Periodicity_search(&GPU_memory, per_param, &calc_time_per_range, input_plane_size, &P_plan.inBin_group[p].Prange[r], &P_plan.inBin_group[p].Prange[r].batches[b], &h_boxcar_widths, harmonic_sum_algorithm, enable_scalloping_loss_removal);
@@ -1278,7 +1312,7 @@ namespace astroaccelerate {
           int nPowerCandidates = GPU_memory.Get_Number_of_Power_Candidates();
           PowerCandidates.push_back(*(new Candidate_List(r)));
           last_entry = PowerCandidates.size()-1;
-          printf("         -> POWER: Total number of peaks found in this range is %d;\n", nPowerCandidates);
+          LOG(log_level::notice, " PSR: Total number of candidates found in this range is " + std::to_string(nPowerCandidates) + ";");
           PowerCandidates[last_entry].Allocate(nPowerCandidates);
           if(harmonic_sum_algorithm==0) {
 			e = cudaMemcpy( &PowerCandidates[last_entry].list[0], &GPU_memory.d_two_B[0], nPowerCandidates*Candidate_List::el*sizeof(float), cudaMemcpyDeviceToHost);
@@ -1294,7 +1328,7 @@ namespace astroaccelerate {
           int nInterbinCandidates = GPU_memory.Get_Number_of_Interbin_Candidates();
           InterbinCandidates.push_back(*(new Candidate_List(r)));
           last_entry = InterbinCandidates.size()-1;
-          printf("         -> INTERBIN: Total number of peaks found in this range is %d;\n", nInterbinCandidates);
+          LOG(log_level::notice, " PSR with inter-binning: Total number of candidates found in this range is " + std::to_string(nInterbinCandidates) + ";");
           InterbinCandidates[last_entry].Allocate(nInterbinCandidates);
           if(harmonic_sum_algorithm==0) {
 			  e = cudaMemcpy( &InterbinCandidates[last_entry].list[0], &GPU_memory.d_two_B[input_plane_size], nInterbinCandidates*Candidate_List::el*sizeof(float), cudaMemcpyDeviceToHost);
@@ -1308,7 +1342,7 @@ namespace astroaccelerate {
           }
 	  
           timer.Stop();
-          printf("         => Copy of candidates took %f ms\n", timer.Elapsed() );
+          time_log.adding("PSR","Device-To-Host",timer.Elapsed());
           copy_time_per_range = copy_time_per_range + timer.Elapsed();
           //---------<
 	
@@ -1317,7 +1351,7 @@ namespace astroaccelerate {
           PowerCandidates[last_entry].Process(h_MSD, &P_plan.inBin_group[p],  1.0);
           InterbinCandidates[last_entry].Process(h_MSD, &P_plan.inBin_group[p], 2.0);
 	
-          printf("\n");
+          //printf("\n");
         } //batches
 
       } // ranges
@@ -1350,10 +1384,10 @@ namespace astroaccelerate {
       InterbinCandidates.clear();
 		
 		
-      printf("     -----------------------\n");
-      printf("     -> This range calculation time: %f ms\n", calc_time_per_range);
-      printf("     -> This range copy time:        %f ms\n", copy_time_per_range);
-      printf("\n");
+      //printf("     -----------------------\n");
+      //printf("     -> This range calculation time: %f ms\n", calc_time_per_range);
+      //printf("     -> This range copy time:        %f ms\n", copy_time_per_range);
+      //printf("\n");
       Total_calc_time = Total_calc_time + calc_time_per_range;
       calc_time_per_range = 0;
       Total_copy_time = Total_copy_time + copy_time_per_range;
@@ -1363,10 +1397,11 @@ namespace astroaccelerate {
 	
     periodicity_timer.Stop();
     Total_periodicity_time = periodicity_timer.Elapsed();
-    printf("\nTimer:\n");
-    printf("Total calculation time: %f ms\n", Total_calc_time);
-    printf("Total copy time:        %f ms\n", Total_copy_time);
-    printf("Total periodicity time: %f ms\n", Total_periodicity_time);	
+    time_log.adding("PSR","total",Total_periodicity_time);
+    //printf("\nTimer:\n");
+    //printf("Total calculation time: %f ms\n", Total_calc_time);
+    //printf("Total copy time:        %f ms\n", Total_copy_time);
+    //printf("Total periodicity time: %f ms\n", Total_periodicity_time);	
 
     cudaDeviceSynchronize();
   };

--- a/src/aa_device_periods.cu
+++ b/src/aa_device_periods.cu
@@ -480,7 +480,6 @@ namespace astroaccelerate {
     
     //---------> Calculate powers and interbinning
     timer.Start();
-    //simple_power_and_interbin( (float2 *) d_two_B, d_half_C, d_one_A, nTimesamples, t_nDMs_per_batch);
     simple_power_and_interbin( (float2 *) d_FFT_complex_output, d_frequency_power, d_frequency_interbin, t_nTimesamples, t_nDMs_per_batch);
     timer.Stop();
     time_log.adding("PSR","power spectrum",timer.Elapsed());
@@ -494,10 +493,8 @@ namespace astroaccelerate {
 
     double total_time, dit_time, MSD_time;
     MSD_plane_profile(gmem->d_MSD, d_frequency_power, gmem->d_previous_partials, d_MSD_workarea, true, (t_nTimesamples>>1), t_nDMs_per_batch, h_boxcar_widths, 0, 0, 0, PSR_strategy.sigma_outlier_rejection_threshold(), PSR_strategy.enable_outlier_rejection(), perform_continuous, &total_time, &dit_time, &MSD_time);
-    //printf("    MSD time: Total: %f ms; DIT: %f ms; MSD: %f ms;\n", total_time, dit_time, MSD_time);
     
     timer.Stop();
-    //printf("         -> MSD took %f ms\n", timer.Elapsed());
     time_log.adding("PSR","MSD",timer.Elapsed());
     (*compute_time) = (*compute_time) + timer.Elapsed();
     //---------<
@@ -535,7 +532,6 @@ namespace astroaccelerate {
         //---------<
     }
     timer.Stop();
-    //printf("         -> harmonic summing took %f ms\n", timer.Elapsed());
     time_log.adding("PSR","harmonic sum",timer.Elapsed());
     (*compute_time) = (*compute_time) + timer.Elapsed();
     //---------<
@@ -562,7 +558,6 @@ namespace astroaccelerate {
         //-------------- Peak finding
     }
     timer.Stop();
-    //printf("         -> Peak finding took %f ms\n", timer.Elapsed());
     time_log.adding("PSR","candidates",timer.Elapsed());
     (*compute_time) = (*compute_time) + timer.Elapsed();
     //---------<

--- a/src/aa_device_periods.cu
+++ b/src/aa_device_periods.cu
@@ -830,7 +830,7 @@ namespace astroaccelerate {
 	//---------> CPU spectral whitening
 	float t_dm_step         = Prange->range.dm_step;
     float t_dm_low          = Prange->range.dm_low;
-	
+	printf("full nTimesamples=%d; half nTimesamples=%d;\n", t_nTimesamples, (t_nTimesamples>>1));
 	// Copy stuff to the host
 	cudaError_t err;
 	char filename[300];
@@ -936,6 +936,7 @@ namespace astroaccelerate {
 		}
 		size_t MSD_pos = d*nSegments;
 		presto_dered_sig(presto_dered, (t_nTimesamples>>1));
+		//cudaMemcpy((float2*) &d_FFT_complex_output[d*(t_nTimesamples>>1)], presto_dered, (t_nTimesamples>>1)*sizeof(float2), cudaMemcpyHostToDevice);
 		dered_with_MSD(MSD_dered, (t_nTimesamples>>1), segment_sizes.data(), nSegments, (float*) &h_segmented_MSD[MSD_pos]);
 		dered_with_MED(MED_dered, (t_nTimesamples>>1), segment_sizes.data(), nSegments, &h_segmented_MED[MSD_pos]);
 		sprintf(filename, "PSR_fft_dered_%f.dat", t_dm_low + t_dm_step*(t_DM_shift + d));
@@ -950,12 +951,13 @@ namespace astroaccelerate {
 	#endif
 	
     //---------> Spectrum whitening
-    timer.Start();
-    cudaStream_t stream; stream = NULL;
-    spectrum_whitening_SGP2((float2 *) d_FFT_complex_output, (t_nTimesamples>>1), t_nDMs_per_batch, true, stream);
-    timer.Stop();
-    printf("         -> Performing spectrum whitening took %f ms\n", timer.Elapsed());
-    (*compute_time) = (*compute_time) + timer.Elapsed();
+    //timer.Start();
+    //cudaStream_t stream; stream = NULL;
+    //spectrum_whitening_SGP2((float2 *) d_FFT_complex_output, (t_nTimesamples>>1), t_nDMs_per_batch, true, stream);
+    //timer.Stop();
+    //printf("         -> Performing spectrum whitening took %f ms\n", timer.Elapsed());
+    //(*compute_time) = (*compute_time) + timer.Elapsed();
+    //---------<
 	
 	#ifdef CPU_SPECTRAL_WHITENING_DEBUG
 	printf("Data copied and power calculation...\n");
@@ -972,10 +974,9 @@ namespace astroaccelerate {
 		fflush(stdout);
 	}
 	printf(" Finished!\n");
+	free(h_fft_input);
 	#endif
 	
-
-    //---------<
 	
     //---------> Calculate powers and interbinning
     timer.Start();
@@ -986,14 +987,6 @@ namespace astroaccelerate {
     (*compute_time) = (*compute_time) + timer.Elapsed();
     //---------<
 
-	//printf("Export:\n");
-	//printf("nTimesamples:%d\n", t_nTimesamples);
-	//printf("nDMs_per_batch:%d\n", t_nDMs_per_batch);
-	//printf("DM_shift:%d\n", t_DM_shift);
-	//printf("dm_step:%f\n", t_dm_step);
-	//printf("dm_low:%f\n", t_dm_low);
-	//printf("sampling_time:%f\n", t_sampling_time);
-    //Export_data_in_range(d_frequency_power, (t_nTimesamples>>1), t_nDMs_per_batch, "Periodicity_input", t_dm_step, t_dm_low, t_sampling_time, t_DM_shift, 1);
 	
     //---------> Mean and StDev on powers
     timer.Start();

--- a/src/aa_device_periods.cu
+++ b/src/aa_device_periods.cu
@@ -1122,6 +1122,12 @@ void checkCudaErrors( cudaError_t CUDA_error){
         //---------<
     }
     else if(harmonic_sum_algorithm == 2) {
+        //---------> PRESTO plus harmonic summing
+        periodicity_presto_plus_harmonic_summing(d_frequency_power, d_power_SNR, gmem->d_power_harmonics, gmem->d_MSD, (t_nTimesamples>>1), t_nDMs_per_batch, per_param.nHarmonics(), enable_scalloping_loss_removal);
+        periodicity_presto_plus_harmonic_summing(d_frequency_interbin, d_interbin_SNR, gmem->d_interbin_harmonics, gmem->d_MSD, t_nTimesamples, t_nDMs_per_batch, per_param.nHarmonics(), enable_scalloping_loss_removal);
+        //---------<
+    }
+    else if(harmonic_sum_algorithm == 3) {
         //---------> PRESTO harmonic summing
         periodicity_presto_harmonic_summing(d_frequency_power, d_power_SNR, gmem->d_power_harmonics, gmem->d_MSD, (t_nTimesamples>>1), t_nDMs_per_batch, per_param.nHarmonics(), enable_scalloping_loss_removal);
         periodicity_presto_harmonic_summing(d_frequency_interbin, d_interbin_SNR, gmem->d_interbin_harmonics, gmem->d_MSD, t_nTimesamples, t_nDMs_per_batch, per_param.nHarmonics(), enable_scalloping_loss_removal);
@@ -1296,7 +1302,8 @@ void checkCudaErrors( cudaError_t CUDA_error){
 
           // simple harmonic sum 0
           // greedy harmonic sum 1
-          // presto harmonic sum 2
+          // presto plus harmonic sum 2
+          // presto harmonic sum 3
           int harmonic_sum_algorithm = 1;
           bool enable_scalloping_loss_removal = true;
           

--- a/src/aa_device_periods.cu
+++ b/src/aa_device_periods.cu
@@ -36,282 +36,18 @@ namespace astroaccelerate {
   
   // define to perform CPU spectral whitening debug
   //#define CPU_SPECTRAL_WHITENING_DEBUG
+  void checkCudaErrors( cudaError_t CUDA_error){
+    if(CUDA_error != cudaSuccess) {
+      printf("CUDA error: %d\n", CUDA_error);
+    }
+  }
   
-  // define to export data from power calculation
-  //#define CPU_POWER_AND_INTERBIN_DEBUG
-  //#define CPU_SNR_DEBUG
-
-  // define to reuse old MSD results to generate a new one (it means new MSD is calculated from more samples) (WORKING WITHIN SAME INBIN VALUE)
-  // #define PS_REUSE_MSD_WITHIN_INBIN
-
-  // experimental and this might not be very useful with real noise BROKEN!
-  // #define PS_REUSE_MSD_THROUGH_INBIN
-
-  //#define OLD_PERIODICITY
-
-
-  // Perhaps it would be best to collapse the structure to either
-  // Inherit from dedispersion plan but introduce additional structure which would index dedispersion range, but the values would be different in dedispersion range Problem would be also how to assign ranges into inBin groups and how to link batches to ranges. Batches to ranges could be done vie Id of the range and inBin groups could be linked via list of ranges, but I'm not sure. 
-
-
-  /**
-   * \class Dedispersion_Range aa_device_periods.cu "src/aa_device_periods.cu"
-   * \brief Class for AstroAccelerate to manage adding dedispersion measure ranges for processing periodicity.
-   * \brief The user should not interact with this class for configuring dedispersion ranges. Instead, the user should use aa_ddtr_plan and aa_ddtr_strategy.
-   * \author -
-   * \date -
-   */
-  class Dedispersion_Range {
-  public:
-    float dm_low;
-    float dm_high;
-    float dm_step;
-    float sampling_time;
-    int inBin;
-    int nTimesamples;
-    int nDMs;
-	
-
-    /** \brief Constructor for Dedispersion_Range. */
-    Dedispersion_Range() {
-      dm_step       = 0;
-      dm_low        = 0;
-      dm_high       = 0;
-      inBin         = 0;
-      nTimesamples  = 0;
-      nDMs          = 0;
-      sampling_time = 0;
-    }
-
-    /** \brief Constructor for Dedispersion_Range. */
-    Dedispersion_Range(float t_dm_low, float t_dm_high, float t_dm_step, int t_inBin, int t_range_timesamples, int t_ndms, float t_sampling_time) {
-      dm_step       = t_dm_step;
-      dm_low        = t_dm_low;
-      dm_high       = t_dm_high;
-      inBin         = t_inBin;
-      nTimesamples  = t_range_timesamples;
-      nDMs          = t_ndms;
-      sampling_time = t_sampling_time;
-    }
-
-    /** \brief Method to assign or change values of an instance after construction. */
-    void Assign(float t_dm_low, float t_dm_high, float t_dm_step, int t_inBin, int t_range_timesamples, int t_ndms, float t_sampling_time) {
-      dm_step       = t_dm_step;
-      dm_low        = t_dm_low;
-      dm_high       = t_dm_high;
-      inBin         = t_inBin;
-      nTimesamples  = t_range_timesamples;
-      nDMs          = t_ndms;
-      sampling_time = t_sampling_time;
-    }
-
-    /** \brief Method to print member variables of an instance. */
-    void print(void) {
-      LOG(log_level::debug, "   dedispersion range:" + std::to_string(dm_low) + "--" + std::to_string(dm_high) + ":" + std::to_string(dm_step) + "; Binning:" + std::to_string(inBin) + "; nTimesamples:" + std::to_string(nTimesamples) + "; nDMs:" + std::to_string(nDMs) + ";");
-    }
-  };
-
-
-  /**
-   * \class Dedispersion_Plan aa_device_periods.cu "src/aa_device_periods.cu"
-   * \brief Class for AstroAccelerate to manage a dedispersion plan for periodicity.
-   * \brief The user should not interact with this class for configuring dedispersion ranges. Instead, the user should use aa_ddtr_plan.
-   * \author -
-   * \date -
-   */
-  class Dedispersion_Plan {
-  public:
-    std::vector<Dedispersion_Range> DD_range;
-    float sampling_time;
-    int nProcessedTimesamples;
-    int max_nDMs;
-
-    /** \brief Method for printing member variable information. */
-    void print() {
-      LOG(log_level::debug, "--------------------------");
-      LOG(log_level::debug, "> De-dispersion plan used:");
-      LOG(log_level::debug, "   sampling time: " + std::to_string(sampling_time));
-      LOG(log_level::debug, "   processed time samples by de-dispersion: " + std::to_string(nProcessedTimesamples));
-      LOG(log_level::debug, "   maximum number of DM trials: " + std::to_string(max_nDMs));
-      for(int f=0; f<(int)DD_range.size(); f++) DD_range[f].print();
-	  LOG(log_level::debug, "--------------------------");
-    }
-  };
-
-  /**
-   * \class Periodicity_Batch aa_device_periods.cu "src/aa_device_periods.cu"
-   * \brief Class for AstroAccelerate to manage processing periodicity data.
-   * \brief The user should not interact with this class for periodicity. Instead, the user should use aa_periodicity_plan and aa_periodicity_strategy.
-   * \author -
-   * \date -
-   */
-  class Periodicity_Batch {
-  public:
-    int nDMs_per_batch;
-    int nTimesamples;
-    int DM_shift;
-    // cuFFT plan? no because cuFFT plan allocates GPU memory
-    MSD_Configuration MSD_conf;
-    std::vector<float> PowerCandidates;
-    std::vector<float> InterbinCandidates;
-
-    /** \brief Constructor for Periodicity_Batch. */
-    Periodicity_Batch(int t_nDMs_per_batch, int t_DM_shift, Dedispersion_Range range, int total_blocks) {
-      nDMs_per_batch = t_nDMs_per_batch;
-      nTimesamples   = range.nTimesamples;
-      DM_shift     = t_DM_shift;
-		
-      MSD_conf = *(new MSD_Configuration((nTimesamples>>1), nDMs_per_batch, 0, total_blocks)); // We divide nTimesamples by 2 because MSD is determined from power spectra (or because of FFT R->C)
-    }
-
-    /** \brief Destructor for Periodicity_Batch. */
-    ~Periodicity_Batch() {
-      //delete MSD_conf;
-    }
-
-    /** \brief Method for printing member variable data for an instance. */
-    void print(int id) {
-      LOG(log_level::debug, "-> Batch:" + std::to_string(id) + "; nDMs:" + std::to_string(nDMs_per_batch) + "; nTimesamples:" + std::to_string(nTimesamples) + "; DM shift:" + std::to_string(DM_shift) + ";");
-    }
-  };
-
-
-  /**
-   * \class Periodicity_Range aa_device_periods.cu "src/aa_device_periods.cu"
-   * \brief Class for AstroAccelerate to manage periodicity ranges.
-   * \brief The user should not use this class for interacting with periodicity. Instead, the user should use aa_periodicity_plan and aa_periodicity_strategy.
-   * \author -
-   * \date -
-   */
-  class Periodicity_Range {
-  public:
-    Dedispersion_Range range;
-    int rangeid;
-    std::vector<Periodicity_Batch> batches;
-    int total_MSD_blocks;
-
-    void Create_Batches(int max_nDMs_in_range, int address_shift) {
-      int nRepeats, nRest;
-      total_MSD_blocks = 0;
-
-      nRepeats = range.nDMs/max_nDMs_in_range;
-      nRest = range.nDMs - nRepeats*max_nDMs_in_range;
-      for(int f=0; f<nRepeats; f++) {
-        Periodicity_Batch batch(max_nDMs_in_range, f*max_nDMs_in_range, range, total_MSD_blocks+address_shift);
-        batches.push_back(batch);
-        total_MSD_blocks = total_MSD_blocks + batch.MSD_conf.nBlocks_total;
-      }
-      if(nRest>0) {
-        Periodicity_Batch batch(nRest, nRepeats*max_nDMs_in_range, range, total_MSD_blocks+address_shift);
-        batches.push_back(batch);
-        total_MSD_blocks = total_MSD_blocks + batch.MSD_conf.nBlocks_total;
-      }
-    }
-
-    void Calculate_Range_Properties(Dedispersion_Range t_range) {
-      range = t_range;
-
-      // Finding nearest lower power of two (because of FFT algorithm)
-      int nearest = (int)floorf(log2f((float)range.nTimesamples));
-      range.nTimesamples = (int) powf(2.0, (float) nearest);
-    }
-
-    Periodicity_Range(Dedispersion_Range t_range, int max_nDMs_in_memory, int t_rangeid, int address_shift) {
-      int max_nDMs_in_range;
-      Calculate_Range_Properties(t_range);
-      max_nDMs_in_range = max_nDMs_in_memory*range.inBin;
-      rangeid = t_rangeid;
-      Create_Batches(max_nDMs_in_range, address_shift);
-    }
-
-    /** \brief Destructor for Periodicity_Range. */
-    ~Periodicity_Range() {
-      batches.clear();
-    }
-
-    /** \brief Method for printing member variable data of an instance. */
-    void print(void) {
-      int size = (int)batches.size();
-	  int batchDM_0 = batches[0].nDMs_per_batch;
-      //printf("  De-dispersion range: %f--%f:%f inBin:%d; nTimesamples:%d; nDMs:%d;\n", range.dm_low, range.dm_high, range.dm_step, range.inBin, range.nTimesamples, range.nDMs);
-      LOG(log_level::notice, "De-dispersion range:" + std::to_string(range.dm_low) + "--" + std::to_string(range.dm_high) + ":" + std::to_string(range.dm_step) + "; Binning:" + std::to_string(range.inBin) + "; nTimesamples:" + std::to_string(range.nTimesamples) + "; nDMs:" + std::to_string(range.nDMs) + ";");
-      if(size>1) {
-        int batchDM_last = batches[size-1].nDMs_per_batch;
-        LOG(log_level::debug, "-> De-dispersion range will be processed in " + std::to_string(size) + " batches each containing " + std::to_string(batchDM_0) + " DM trials with tail of " + std::to_string(batchDM_last) + " DM trials");
-      }
-      else LOG(log_level::debug, "-> Periodicity search will run 1 batch containing " + std::to_string(batchDM_0) + " DM trials.");
-      float MSD_block_mem = (total_MSD_blocks*MSD_PARTIAL_SIZE*sizeof(float))/(1024.0*1024.0);
-      LOG(log_level::debug, "-> Total number of MSD blocks is " + std::to_string(total_MSD_blocks) + " which is " + std::to_string(MSD_block_mem) + "MB");
-      #ifdef GPU_PERIODICITY_SEARCH_DEBUG
-          printf("--------- Batches ----------\n");
-          for(int f=0; f<(int)batches.size(); f++) batches[f].print();
-          printf("\n");
-      #endif
-    }
-  };
-
-  /**
-   * \class Periodicity_inBin_Group aa_device_periods.cu "src/aa_device_periods.cu"
-   * \brief Class for AstroAccelerate to manage inBin data for periodicity.
-   * \brief The user should not use this class for interacting with periodicity. Instead the user should use aa_periodicity_plan and aa_periodicity_strategy.
-   * \author -
-   * \date -
-   */
-  class Periodicity_inBin_Group {
-  public:
-    int total_MSD_blocks;
-    std::vector<Periodicity_Range> Prange;
-	
-    void print(void) {
-      for(int f=0; f<(int) Prange.size(); f++){
-        printf("  ->Periodicity range: %d\n", f);
-        Prange[f].print();
-      }
-    }
-  };
-
-  /**
-   * \class AA_Periodicity_Plan aa_device_periods.cu "src/aa_device_periods.cu"
-   * \brief Class for AstroAccelerate to manage periodicity plan.
-   * \brief The user should not use this class for interacting with periodicity. Instead the user should use aa_periodicity_plan.
-   * \author -
-   * \date -
-   */
-  class AA_Periodicity_Plan {
-  public:
-    int nHarmonics;
-    int max_total_MSD_blocks;
-    int max_nTimesamples;
-    int max_nDMs;
-    int max_nDMs_in_memory;
-    size_t input_plane_size;
-    size_t cuFFT_workarea_size;
-    std::vector<Periodicity_inBin_Group> inBin_group;
-
-    /** \brief Destructor for AA_Periodicity_Plan. */
-    ~AA_Periodicity_Plan() {
-      inBin_group.clear();
-    }
-	
-    /** \brief Clear inBin data from inBin_group. */
-    void clear(){
-      inBin_group.clear();
-    }
-	
-    /** \brief Method for printing member variable data of an instance. */
-    void print(void) {
-      printf("max_total_MSD_blocks: %d MSD blocks;\n", max_total_MSD_blocks);
-      printf("max_nTimesamples:     %d time samples;\n", max_nTimesamples);
-      printf("max_nDMs:             %d DMs;\n", max_nDMs);
-      printf("max_nDMs_in_memory:   %d DMs;\n", max_nDMs_in_memory);
-      printf("input_plane_size:     %zu floating point numbers = %0.2f MB;\n", input_plane_size, ((float) input_plane_size*sizeof(float))/(1024.0*1024.0));
-      printf("cuFFT_workarea_size:  %zu = %0.2f MB;\n", cuFFT_workarea_size, (float) cuFFT_workarea_size/(1024.0*1024.0));
-      for(int f=0; f<(int) inBin_group.size(); f++){
-        printf("inBin group: %d\n", f);
-        inBin_group[f].print();
-      }
-    }
-  };
+  void printMem(){
+    size_t free = 0;
+    size_t total = 0;
+    cudaMemGetInfo(&free, &total);
+    printf("Free memory: %zu;\n", free);
+  }
 
   /**
    * \class Candidate_List aa_device_periods.cu "src/aa_device_periods.cu"
@@ -333,18 +69,6 @@ namespace astroaccelerate {
       float sd       = MSD[1];
       float modifier = MSD[2];
       SNR = (value - (harmonic+1)*mean)/(sd + harmonic*modifier);
-      return(SNR);
-    }
-
-    /**
-     * \brief Calculates the signal-to-noise ratio (SNR) using a white-noise approximation.
-     * \returns A white noise approximation of the signal-to-noise ratio (SNR).
-     */
-    float white_noise_approximation(float value, int harmonic, float *MSD) {
-      float SNR;
-      float mean = MSD[0];
-      float sd   = MSD[1];
-      SNR = (value - (harmonic+1)*mean)/(sqrt(harmonic+1)*sd);
       return(SNR);
     }
 
@@ -370,31 +94,30 @@ namespace astroaccelerate {
     }
 
     /** \brief Processes the periodicity inBin data group. */
-    void Process(float *MSD, Periodicity_inBin_Group *inBin_group, float mod) {
-      float dm_step       = inBin_group->Prange[rangeid].range.dm_step;
-      float dm_low        = inBin_group->Prange[rangeid].range.dm_low;
-      float sampling_time = inBin_group->Prange[rangeid].range.sampling_time;
-      float nTimesamples  = inBin_group->Prange[rangeid].range.nTimesamples;
+    void Process(float *MSD, aa_periodicity_range *Prange, float mod) {
+      float dm_step       = Prange->range.dm_step();
+      float dm_low        = Prange->range.dm_low();
+      float sampling_time = Prange->range.sampling_time();
+      float nTimesamples  = Prange->range.nTimesamples();
       int nPoints_before  = size();
       int harmonics;
 
-      for(int c=0; c<(int)size(); c++) {
+      for(size_t c=0; c< size(); c++) {
         harmonics = (int) list[c*el+3];
         list[c*el+0] = list[c*el+0]*dm_step + dm_low;
         list[c*el+1] = list[c*el+1]*(1.0/(sampling_time*nTimesamples*mod));
-        //list[c*el+2] = white_noise_approximation(list[c*el+2], list[c*el+3], MSD);
         list[c*el+2] = (list[c*el+2] - MSD[2*harmonics])/(MSD[2*harmonics+1]);
         list[c*el+3] = list[c*el+3];
       }
     }
-	
+    
     /** \brief Rescales and then processes inBin data group. */
-    void Rescale_Threshold_and_Process(float *MSD, Periodicity_inBin_Group *inBin_group, float sigma_cutoff, float mod) {
+    void Rescale_Threshold_and_Process(float *MSD, aa_periodicity_range *Prange, float sigma_cutoff, float mod) {
       float SNR;
-      float dm_step       = inBin_group->Prange[rangeid].range.dm_step;
-      float dm_low        = inBin_group->Prange[rangeid].range.dm_low;
-      float sampling_time = inBin_group->Prange[rangeid].range.sampling_time;
-      int nTimesamples    = inBin_group->Prange[rangeid].range.nTimesamples;
+      float dm_step       = Prange->range.dm_step();
+      float dm_low        = Prange->range.dm_low();
+      float sampling_time = Prange->range.sampling_time();
+      int nTimesamples    = Prange->range.nTimesamples();
       int nPoints_before = size();
       int nPoints_after;
 
@@ -402,7 +125,6 @@ namespace astroaccelerate {
       for(int c=0; c<(int)size(); c++) {
         float oldSNR = list[c*el+2];
         int harmonics = (int) list[c*el+3];
-        //SNR = white_noise_approximation(list[c*el+2], list[c*el+3], MSD);
         SNR = (list[c*el+2] - MSD[2*harmonics])/(MSD[2*harmonics+1]);
 
         if(SNR>sigma_cutoff) {
@@ -436,55 +158,56 @@ namespace astroaccelerate {
     float *d_one_A;
     float *d_two_B;
     float *d_half_C;
-	
+    
     ushort *d_power_harmonics;
     ushort *d_interbin_harmonics;
-	
+    
     // Candidate list
     int *gmem_power_peak_pos;
     int *gmem_interbin_peak_pos;
-	
+    
     // MSD
     float *d_MSD;
     float *d_previous_partials;
     float *d_all_blocks;
-	
+    
     // cuFFT
     void *cuFFT_workarea;
-	
-    void Allocate(AA_Periodicity_Plan *P_plan){
-      MSD_interpolated_size = P_plan->nHarmonics;
-      MSD_DIT_size = ((int) floorf(log2f((float)P_plan->nHarmonics))) + 2;
-      size_t t_input_plane_size = P_plan->input_plane_size;
-		
+    
+    void Allocate(aa_periodicity_strategy &PSR_strategy){
+      int nHarmonics = PSR_strategy.nHarmonics();
+      MSD_interpolated_size = nHarmonics;
+      MSD_DIT_size = ((int) floorf(log2f((float) nHarmonics))) + 2;
+      size_t t_input_plane_size = PSR_strategy.input_plane_size();
+        
       if ( cudaSuccess != cudaMalloc((void **) &d_one_A,  sizeof(float)*t_input_plane_size )) printf("Periodicity Allocation error! d_one_A\n");
       if ( cudaSuccess != cudaMalloc((void **) &d_two_B,  sizeof(float)*2*t_input_plane_size )) printf("Periodicity Allocation error! d_two_B\n");
       if ( cudaSuccess != cudaMalloc((void **) &d_half_C,  sizeof(float)*t_input_plane_size/2 )) printf("Periodicity Allocation error! d_spectra_Real\n");
-		
+        
       if ( cudaSuccess != cudaMalloc((void **) &d_power_harmonics, sizeof(ushort)*t_input_plane_size )) printf("Periodicity Allocation error! d_harmonics\n");
       if ( cudaSuccess != cudaMalloc((void **) &d_interbin_harmonics, sizeof(ushort)*t_input_plane_size )) printf("Periodicity Allocation error! d_harmonics\n");
-		
+        
       if ( cudaSuccess != cudaMalloc((void**) &gmem_power_peak_pos, 1*sizeof(int)) )  printf("Periodicity Allocation error! gmem_power_peak_pos\n");
       if ( cudaSuccess != cudaMalloc((void**) &gmem_interbin_peak_pos, 1*sizeof(int)) )  printf("Periodicity Allocation error! gmem_interbin_peak_pos\n");
-		
+        
       if ( cudaSuccess != cudaMalloc((void**) &d_MSD, sizeof(float)*MSD_interpolated_size*2)) {printf("Periodicity Allocation error! d_MSD\n");}
       
       if ( cudaSuccess != cudaMalloc((void**) &d_previous_partials, sizeof(float)*MSD_DIT_size*MSD_PARTIAL_SIZE)) {printf("Periodicity Allocation error! d_previous_partials\n");}
-      if ( cudaSuccess != cudaMalloc((void**) &d_all_blocks, sizeof(float)*P_plan->max_total_MSD_blocks*MSD_PARTIAL_SIZE)) {printf("Periodicity Allocation error! d_MSD\n");}
-		
-      if ( cudaSuccess != cudaMalloc((void **) &cuFFT_workarea, P_plan->cuFFT_workarea_size) ) {printf("Periodicity Allocation error! cuFFT_workarea\n");}
+      if ( cudaSuccess != cudaMalloc((void**) &d_all_blocks, sizeof(float)*PSR_strategy.max_total_MSD_blocks()*MSD_PARTIAL_SIZE)) {printf("Periodicity Allocation error! d_MSD\n");}
+        
+      if ( cudaSuccess != cudaMalloc((void **) &cuFFT_workarea, PSR_strategy.cuFFT_workarea_size()) ) {printf("Periodicity Allocation error! cuFFT_workarea\n");}
     }
-	
+    
     void Reset_MSD(){
       cudaMemset(d_MSD, 0, MSD_interpolated_size*2*sizeof(float));
       cudaMemset(d_previous_partials, 0, MSD_DIT_size*MSD_PARTIAL_SIZE*sizeof(float));
     }
-	
+    
     void Reset_Candidate_List(){
       cudaMemset(gmem_power_peak_pos, 0, sizeof(int));
       cudaMemset(gmem_interbin_peak_pos, 0, sizeof(int));
     }
-	
+    
     int Get_Number_of_Power_Candidates(){
       int temp;
       cudaError_t e = cudaMemcpy(&temp, gmem_power_peak_pos, sizeof(int), cudaMemcpyDeviceToHost);
@@ -495,7 +218,7 @@ namespace astroaccelerate {
       
       return( (int) temp);
     }
-	
+    
     int Get_Number_of_Interbin_Candidates(){
       int temp;
       cudaError_t e = cudaMemcpy(&temp, gmem_interbin_peak_pos, sizeof(int), cudaMemcpyDeviceToHost);
@@ -506,7 +229,7 @@ namespace astroaccelerate {
       
       return( (int) temp);
     }
-	
+    
     void Get_MSD(float *h_MSD){
       cudaError_t e = cudaMemcpy(h_MSD, d_MSD, MSD_interpolated_size*2*sizeof(float), cudaMemcpyDeviceToHost);
 
@@ -514,7 +237,7 @@ namespace astroaccelerate {
         LOG(log_level::error, "Could not cudaMemcpy in aa_device_periods.cu (" + std::string(cudaGetErrorString(e)) + ")");
       }
     }
-	
+    
     void Get_MSD_partials(float *h_MSD_partials){
       cudaError_t e = cudaMemcpy(h_MSD_partials, d_previous_partials, MSD_DIT_size*MSD_PARTIAL_SIZE*sizeof(float), cudaMemcpyDeviceToHost);
       
@@ -522,7 +245,7 @@ namespace astroaccelerate {
         LOG(log_level::error, "Could not cudaMemcpy in aa_device_periods.cu (" + std::string(cudaGetErrorString(e)) + ")");
       }
     }
-	
+    
     void Set_MSD_partials(float *h_MSD_partials){
       cudaError_t e = cudaMemcpy(d_previous_partials, h_MSD_partials, MSD_PARTIAL_SIZE*sizeof(float), cudaMemcpyHostToDevice);
 
@@ -530,7 +253,7 @@ namespace astroaccelerate {
         LOG(log_level::error, "Could not cudaMemcpy in aa_device_periods.cu (" + std::string(cudaGetErrorString(e)) + ")");
       }
     }
-	
+    
     /** \brief Destructor for GPU_Memory_for_Periodicity_Search. */
     ~GPU_Memory_for_Periodicity_Search(){
       cudaFree(d_one_A);
@@ -548,170 +271,7 @@ namespace astroaccelerate {
   };
 
 
-
-  void Create_DD_plan(Dedispersion_Plan *D_plan, int nRanges, float *dm_low, float *dm_high, float *dm_step, int *inBin, int nTimesamples, int const*const ndms, float sampling_time){
-    int max_nDMs = 0;
-    for(int f=0; f<nRanges; f++){
-      Dedispersion_Range trange;
-      trange.Assign(dm_low[f], dm_high[f], dm_step[f], inBin[f], nTimesamples/inBin[f], ndms[f], sampling_time);
-      D_plan->DD_range.push_back(trange);
-      if(ndms[f]>max_nDMs) max_nDMs = ndms[f];
-    }
-	
-    D_plan->nProcessedTimesamples = nTimesamples;
-    D_plan->max_nDMs = max_nDMs;
-    D_plan->sampling_time = sampling_time;
-  }
-
-  int Calculate_max_nDMs_in_memory(size_t max_nTimesamples, size_t max_nDMs, size_t memory_available, float multiple_float, float multiple_ushort) {
-    size_t max_nDMs_in_memory, itemp;
-
-    size_t memory_per_DM = ((max_nTimesamples+2)*(multiple_float*sizeof(float) + multiple_ushort*sizeof(ushort)));
-    LOG(log_level::debug, "   Memory required for one DM trial is " + std::to_string((float) memory_per_DM/(1024.0*1024.0)) + "MB");
-    max_nDMs_in_memory = (memory_available*0.98)/((max_nTimesamples+2)*(multiple_float*sizeof(float) + multiple_ushort*sizeof(ushort))); // 1 for real input real, 2 for complex output, 2 for complex cuFFT, 1 for peaks + 1 ushort
-    if((max_nDMs+PHS_NTHREADS)<max_nDMs_in_memory) { //if we can fit all DM trials from largest range into memory then we need to find nearest higher multiple of PHS_NTHREADS
-      itemp = (int)(max_nDMs/PHS_NTHREADS);
-      if((max_nDMs%PHS_NTHREADS)>0) itemp++;
-      max_nDMs_in_memory = itemp*PHS_NTHREADS;
-    }
-    itemp = (int)(max_nDMs_in_memory/PHS_NTHREADS); // if we cannot fit all DM trials from largest range into memory we find nearest lower multiple of PHS_NTHREADS
-    max_nDMs_in_memory = itemp*PHS_NTHREADS;
-
-    return(max_nDMs_in_memory);
-  }
-  
-  
-  
-  size_t Get_max_cuFFT_workarea_size(AA_Periodicity_Plan *P_plan){
-	  // This whole unfortunate function is necessary because as of CUDA11 cufftMakePlan1d may return size of the cuFFT workarea larger (up to 2x) for some input values of nDMs (number of FFTs calculated). This value is larger then the value returned for some other larger value of nDMs thus we cannot rely on getting size of the cuFFT workarea just for largest number of FFT calculated.
-      cufftHandle plan_input;
-      cufftResult cufft_error;
-      size_t max_cuFFT_workarea_size = 0;
-	  size_t temporary_cuFFT_workarea_size = 0;
-	  
-	  for(int p=0; p<(int) P_plan->inBin_group.size(); p++) {
-		  for(int r=0; r<(int) P_plan->inBin_group[p].Prange.size(); r++) {
-			  for(int b=0; b<(int)P_plan->inBin_group[p].Prange[r].batches.size(); b++) {
-				  //int    inbin        = P_plan.inBin_group[p].Prange[r].inBin;
-				  size_t nTimesamples = P_plan->inBin_group[p].Prange[r].batches[b].nTimesamples;
-				  size_t nDMs         = P_plan->inBin_group[p].Prange[r].batches[b].nDMs_per_batch;
-				  
-				  cufftCreate(&plan_input);
-				  cufftSetAutoAllocation(plan_input, false);
-				  cufft_error = cufftMakePlan1d(plan_input, nTimesamples, CUFFT_R2C, nDMs, &temporary_cuFFT_workarea_size);
-				  if (CUFFT_SUCCESS != cufft_error){
-					  printf("CUFFT error: %d", cufft_error);
-				  }
-				  cufftDestroy(plan_input);
-				  
-				  if(temporary_cuFFT_workarea_size > max_cuFFT_workarea_size) {
-					  max_cuFFT_workarea_size = temporary_cuFFT_workarea_size;
-				  }
-			  }
-		  }
-	  }
-	  
-      return(max_cuFFT_workarea_size);
-  }
-
-  void Create_Periodicity_Plan(AA_Periodicity_Plan *P_plan, Dedispersion_Plan *DD_plan, size_t max_nDMs_in_memory) {
-    int oldinBin, last;
-    int max_nTimesamples;
-    int max_total_MSD_blocks;
-	
-    int nearest = (int)floorf(log2f((float) DD_plan->nProcessedTimesamples));
-    P_plan->max_nTimesamples     = (int) powf(2.0, (float) nearest);
-    P_plan->max_nDMs             = DD_plan->max_nDMs;
-    P_plan->max_total_MSD_blocks = 0;
-	
-    oldinBin = 0;
-    last = 0;
-    max_nTimesamples     = 0;
-    for(int f=0; f<(int)DD_plan->DD_range.size(); f++) {
-      int localinBin = DD_plan->DD_range[f].inBin;
-
-      if(oldinBin != localinBin) {
-        P_plan->inBin_group.push_back( *(new Periodicity_inBin_Group) );
-        last = (int) P_plan->inBin_group.size() - 1;
-        P_plan->inBin_group[last].total_MSD_blocks = 0;
-        oldinBin = localinBin;
-      }
-		
-      Periodicity_Range Prange(DD_plan->DD_range[f], max_nDMs_in_memory, f, P_plan->inBin_group[last].total_MSD_blocks);
-      P_plan->inBin_group[last].Prange.push_back(Prange);
-      P_plan->inBin_group[last].total_MSD_blocks += Prange.total_MSD_blocks;
-      if(max_nTimesamples<Prange.range.nTimesamples) max_nTimesamples = Prange.range.nTimesamples;
-    }
-	
-    max_total_MSD_blocks = 0;
-    for(int f=0; f<(int)P_plan->inBin_group.size();f++){
-      if(max_total_MSD_blocks<P_plan->inBin_group[f].total_MSD_blocks) max_total_MSD_blocks=P_plan->inBin_group[f].total_MSD_blocks;
-    }
-	
-    P_plan->max_total_MSD_blocks = max_total_MSD_blocks;
-    P_plan->max_nTimesamples     = max_nTimesamples;
-  }
-
-  bool Find_Periodicity_Plan(int *max_nDMs_in_memory, AA_Periodicity_Plan *P_plan, Dedispersion_Plan *DD_plan, size_t memory_available){
-      size_t memory_allocated, memory_for_data;
-      size_t input_plane_size;
-      
-      int nearest = (int) floorf(log2f((float) DD_plan->nProcessedTimesamples));
-      size_t t_max_nTimesamples = (size_t) powf(2.0, (float) nearest);
-      size_t t_max_nDMs = (size_t) DD_plan->max_nDMs;
-      size_t t_max_nDMs_in_memory = 0;
-      size_t t_max_cuFFT_workarea_size = 0;
-      
-      
-      float multiple_float  = 5.5;
-      float multiple_ushort = 2.0; 
-      
-      
-      LOG(log_level::debug, "> FINDING PERIODICITY PLAN:");
-      memory_for_data = memory_available;
-      do {
-          //printf("   Memory_for_data: %zu = %0.3f MB\n", memory_for_data, (float) memory_for_data/(1024.0*1024.0));
-          LOG(log_level::debug, "   Memory available: " + std::to_string(memory_for_data) + " = " + std::to_string((float) memory_for_data/(1024.0*1024.0)) + "MB");
-          t_max_nDMs_in_memory = Calculate_max_nDMs_in_memory(t_max_nTimesamples, t_max_nDMs, memory_for_data, multiple_float, multiple_ushort);
-          if(t_max_nDMs_in_memory==0) {
-              LOG(log_level::error, "Error not enough memory for periodicity search!");
-              return(false);
-          }
-          input_plane_size = (t_max_nTimesamples+2)*t_max_nDMs_in_memory;
-          memory_allocated = input_plane_size*multiple_float*sizeof(float) + multiple_ushort*input_plane_size*sizeof(ushort);
-          LOG(log_level::debug, "   Maximum number of DM trials which fit into memory is: " +  std::to_string(t_max_nDMs_in_memory));
-          LOG(log_level::debug, "   Maximum time trials: " +  std::to_string(t_max_nTimesamples));
-          LOG(log_level::debug, "   Input plane size: " +  std::to_string((((float) input_plane_size*sizeof(float))/(1024.0*1024.0))) + " MB;")
-          
-          
-          Create_Periodicity_Plan(P_plan, DD_plan, t_max_nDMs_in_memory);
-          t_max_cuFFT_workarea_size = Get_max_cuFFT_workarea_size(P_plan);
-          
-          //-------- Additional memory for MSD ------
-          int nDecimations = ((int) floorf(log2f((float)P_plan->nHarmonics))) + 2;
-          size_t additional_data_size = P_plan->max_total_MSD_blocks*MSD_PARTIAL_SIZE*sizeof(float) + nDecimations*2*MSD_RESULTS_SIZE*sizeof(float) + P_plan->nHarmonics*2*sizeof(float) + 2*sizeof(int);
-          memory_allocated = memory_allocated + additional_data_size;
-          LOG(log_level::debug, "   Memory available for the component: " + std::to_string((float) memory_available/(1024.0*1024.0)) + "MB (" + std::to_string(memory_available) + " bytes)");
-          LOG(log_level::debug, "   Memory allocated by the component: " + std::to_string((float) memory_allocated/(1024.0*1024.0)) + "MB (" + std::to_string(memory_allocated) + " bytes)");
-          
-          if(memory_allocated>memory_available) {
-              LOG(log_level::warning, "--> Not enough memory for given configuration of periodicity plan. Calculating new plan...");
-              memory_for_data = memory_for_data - additional_data_size;
-              P_plan->clear();
-          }
-      } while(memory_allocated > memory_available);
-      
-      P_plan->max_nDMs_in_memory = (int) t_max_nDMs_in_memory;
-      P_plan->input_plane_size = (P_plan->max_nTimesamples+2)*t_max_nDMs_in_memory;
-      P_plan->cuFFT_workarea_size = t_max_cuFFT_workarea_size;
-      LOG(log_level::debug, "   Workarea size: " + std::to_string((float) t_max_cuFFT_workarea_size/(1024.0*1024.0)) + "MB");
-      
-      *max_nDMs_in_memory = (int) t_max_nDMs_in_memory;
-      LOG(log_level::debug, "--------------------------");
-      return(true);
-  }
-
-  void Copy_data_for_periodicity_search(float *d_one_A, float **dedispersed_data, Periodicity_Batch *batch){ //TODO add "cudaStream_t stream1"
+  void Copy_data_for_periodicity_search(float *d_one_A, float **dedispersed_data, aa_periodicity_batch *batch){ //TODO add "cudaStream_t stream1"
     int nStreams = 16;
     cudaStream_t stream_copy[16];
     cudaError_t e;
@@ -726,10 +286,10 @@ namespace astroaccelerate {
       }
     }
 
-	size_t stream_offset = batch->nTimesamples;
+    size_t stream_offset = batch->nTimesamples;
 
     #pragma omp parallel for num_threads(nStreams) shared(h_small_dedispersed_data, data_size, d_one_A, stream_copy, stream_offset)
-    for(int ff=0; ff<batch->nDMs_per_batch; ff++){
+    for(int ff=0; ff<(int) batch->nDMs_per_batch; ff++){
       int id_stream = omp_get_thread_num();
       memcpy(h_small_dedispersed_data + id_stream*stream_offset, dedispersed_data[batch->DM_shift + ff], data_size);
       //e = cudaMemcpy( &d_one_A[ff*batch->nTimesamples], dedispersed_data[batch->DM_shift + ff], batch->nTimesamples*sizeof(float), cudaMemcpyHostToDevice);      
@@ -760,33 +320,33 @@ namespace astroaccelerate {
     int lower, higher, inner_DM_shift;
     int data_mod = 3;
     if(DMs_per_file<0) DMs_per_file=nDMs;
-	
+    
     float *h_data, *h_export;
     size_t data_size = ((size_t) nTimesamples)*((size_t) nDMs);
     size_t export_size = ((size_t) nTimesamples)*((size_t) DMs_per_file)*data_mod;
     h_data = new float[data_size];
     h_export = new float[export_size];
-	
+    
     cudaError_t e = cudaMemcpy(h_data, GPU_data, data_size*sizeof(float), cudaMemcpyDeviceToHost);
     
     if(e != cudaSuccess) {
       LOG(log_level::error, "Could not cudaMemcpy in aa_device_periods.cu (" + std::string(cudaGetErrorString(e)) + ")");
     }
-	
+    
     int nRepeats = nDMs/DMs_per_file;
     int nRest = nDMs%DMs_per_file;
     std::vector<int> chunk_size;
     for(int f=0; f<nRepeats; f++) chunk_size.push_back(DMs_per_file);
     if(nRest>0) chunk_size.push_back(nRest);
     printf("Data will be exported into %d files\n", (int) chunk_size.size());
-	
+    
     inner_DM_shift = 0;
     for(int i=0; i<(int) chunk_size.size(); i++){
       lower = outer_DM_shift + inner_DM_shift;
       higher = outer_DM_shift + inner_DM_shift + chunk_size[i];
       sprintf(final_filename,"%s_%f_%f.dat", filename, lower*dm_step+dm_low, higher*dm_step+dm_low);
       printf("Exporting file %s\n", final_filename);
-		
+        
       for(int dm = 0; dm<chunk_size[i]; dm++) {
         for(int t=0; t<nTimesamples; t++){
           int pos = dm*nTimesamples + t;
@@ -795,71 +355,68 @@ namespace astroaccelerate {
           h_export[data_mod*pos + 2] = h_data[(inner_DM_shift+dm)*nTimesamples + t];
         }
       }
-		
+        
       FILE *fp_out;
       if (( fp_out = fopen(final_filename, "wb") ) == NULL) {
         LOG(log_level::error, "Error opening output file!");
       }
       fwrite(h_export, nTimesamples*chunk_size[i]*sizeof(float), 3, fp_out);
       fclose(fp_out);
-		
+        
       inner_DM_shift = inner_DM_shift + chunk_size[i];
     }
-	
+    
     delete [] h_data;
     delete [] h_export;
   }
 
-void checkCudaErrors( cudaError_t CUDA_error){
- if(CUDA_error != cudaSuccess) {
-  printf("CUDA error: %d\n", CUDA_error);
- }
-}
   /**
    * \brief Performs a periodicity search on the GPU.
    * \todo Clarify the difference between Periodicity_search and GPU_periodicity.
    **/
-  void Periodicity_search(GPU_Memory_for_Periodicity_Search *gmem, aa_periodicity_strategy per_param, double *compute_time, size_t input_plane_size, Periodicity_Range *Prange, Periodicity_Batch *batch, std::vector<int> *h_boxcar_widths, int harmonic_sum_algorithm, bool enable_scalloping_loss_removal){
+  void Periodicity_search(GPU_Memory_for_Periodicity_Search *gmem, aa_periodicity_strategy PSR_strategy, double *compute_time, size_t input_plane_size, aa_periodicity_range *Prange, aa_periodicity_batch *batch, std::vector<int> *h_boxcar_widths, int harmonic_sum_algorithm, bool enable_scalloping_loss_removal){
     bool transposed_data = true;
     if(harmonic_sum_algorithm != 0){
         transposed_data = false;
     }
     TimeLog time_log;
-	
+    
     int local_max_list_size = (input_plane_size)/4;
-	
+    if(local_max_list_size > 1073741824) local_max_list_size = 1073741824;
+    
+    
     float *d_dedispersed_data, *d_FFT_complex_output, *d_frequency_power, *d_frequency_interbin, *d_frequency_power_CT, *d_frequency_interbin_CT, *d_power_SNR, *d_interbin_SNR, *d_power_list, *d_interbin_list, *d_MSD_workarea;
     
-	d_dedispersed_data      = gmem->d_one_A;
+    d_dedispersed_data      = gmem->d_one_A;
     d_FFT_complex_output    = gmem->d_two_B;
     d_MSD_workarea          = gmem->d_two_B;
     d_frequency_power       = gmem->d_half_C;
     d_frequency_interbin    = gmem->d_one_A;
-	if(transposed_data){
-		d_frequency_power_CT    = &gmem->d_two_B[0];
-		d_frequency_interbin_CT = &gmem->d_two_B[input_plane_size];
-		d_power_SNR             = gmem->d_half_C;
-		d_interbin_SNR          = gmem->d_one_A;
-		d_power_list            = &gmem->d_two_B[0];
-		d_interbin_list         = &gmem->d_two_B[input_plane_size];
-	}
-	else {
-		d_frequency_power_CT    = NULL;
-		d_frequency_interbin_CT = NULL;
-		d_power_SNR             = &gmem->d_two_B[0];
-		d_interbin_SNR          = &gmem->d_two_B[input_plane_size];
-		d_power_list            = gmem->d_half_C;
-		d_interbin_list         = gmem->d_one_A;
-	}
-	
+    if(transposed_data){
+        d_frequency_power_CT    = &gmem->d_two_B[0];
+        d_frequency_interbin_CT = &gmem->d_two_B[input_plane_size];
+        d_power_SNR             = gmem->d_half_C;
+        d_interbin_SNR          = gmem->d_one_A;
+        d_power_list            = &gmem->d_two_B[0];
+        d_interbin_list         = &gmem->d_two_B[input_plane_size];
+    }
+    else {
+        d_frequency_power_CT    = NULL;
+        d_frequency_interbin_CT = NULL;
+        d_power_SNR             = &gmem->d_two_B[0];
+        d_interbin_SNR          = &gmem->d_two_B[input_plane_size];
+        d_power_list            = gmem->d_half_C;
+        d_interbin_list         = gmem->d_one_A;
+    }
+    
     int t_nTimesamples      = batch->nTimesamples;
     int t_nTSamplesFFT      = (t_nTimesamples>>1) + 1;
     int t_nDMs_per_batch    = batch->nDMs_per_batch;
     int t_DM_shift          = batch->DM_shift;
-    int t_inBin             = Prange->range.inBin;
-	
+    int t_inBin             = 1; // this is because nTimesamples and sampling time is already adjusted for binning
+    
     aa_gpu_timer timer;
-	
+    
     //---------> cuFFT
     timer.Start();
     cufftHandle plan_input;
@@ -870,16 +427,16 @@ void checkCudaErrors( cudaError_t CUDA_error){
     cufft_error = cufftCreate(&plan_input);
     if (CUFFT_SUCCESS != cufft_error) printf("CUFFT error: %d", cufft_error);
     cufftSetAutoAllocation(plan_input, false);
-	
+    
     cufft_error = cufftMakePlan1d(plan_input, t_nTimesamples, CUFFT_R2C, t_nDMs_per_batch, &cuFFT_workarea_size);
     if (CUFFT_SUCCESS != cufft_error) printf("CUFFT error: %d", cufft_error);
-	
+    
     cufft_error = cufftSetWorkArea(plan_input, gmem->cuFFT_workarea);
     if (CUFFT_SUCCESS != cufft_error) printf("CUFFT error: %d", cufft_error);
 
     cufft_error = cufftExecR2C(plan_input, (cufftReal *)d_dedispersed_data, (cufftComplex *)d_FFT_complex_output);
     if ( cufft_error != CUFFT_SUCCESS) printf("CUFFT error: %d\n", cufft_error);
-	
+    
     cufft_error = cufftDestroy(plan_input);
     if ( cufft_error != CUFFT_SUCCESS) printf("CUFFT error: %d\n", cufft_error);
 
@@ -887,144 +444,12 @@ void checkCudaErrors( cudaError_t CUDA_error){
     time_log.adding("PSR","cuFFT",timer.Elapsed());
     (*compute_time) = (*compute_time) + timer.Elapsed();
     //---------<
-	
-	
-	#ifdef CPU_SPECTRAL_WHITENING_DEBUG
-	float t_dm_step         = Prange->range.dm_step;
-	float t_dm_low          = Prange->range.dm_low;
-		
-	//---------> CPU spectral whitening
-	printf("full nTimesamples=%d; half nTimesamples=%d;\n", t_nTimesamples, t_nTSamplesFFT);
-	// Copy stuff to the host
-	cudaError_t err;
-	char filename[300];
-	size_t fft_input_size_bytes = t_nTSamplesFFT*t_nDMs_per_batch*sizeof(float2);
-	size_t fft_power_size_bytes = t_nTSamplesFFT*t_nDMs_per_batch*sizeof(float);
-	size_t fft_ddtr_size_bytes  = t_nTimesamples*t_nDMs_per_batch*sizeof(float);
-	float2 *h_fft_input;
-	float  *h_fft_power;
-	float  *h_ddtr_data;
-	printf("Data copied and power calculation...\n");
-	h_fft_input = (float2*) malloc(fft_input_size_bytes);
-	h_fft_power = (float*) malloc(fft_power_size_bytes);
-	h_ddtr_data = (float*) malloc(fft_ddtr_size_bytes);
-	
-	err = cudaMemcpy(h_fft_input, d_FFT_complex_output, fft_input_size_bytes, cudaMemcpyDeviceToHost);
-	if(err != cudaSuccess) printf("CUDA error\n");
-	err = cudaMemcpy(h_ddtr_data, d_dedispersed_data, fft_ddtr_size_bytes, cudaMemcpyDeviceToHost);
-	if(err != cudaSuccess) printf("CUDA error\n");
-	
-	for(int d=0; d<t_nDMs_per_batch; d++){
-		for(int s=0; s<t_nTSamplesFFT; s++){
-			size_t pos = d*t_nTSamplesFFT + s;
-			h_fft_power[pos] = h_fft_input[pos].x*h_fft_input[pos].x + h_fft_input[pos].y*h_fft_input[pos].y;
-		}
-	}
-	
-	
-	// Export data to file
-	printf("Exporting fft data to file...\n");
-	for(int d=0; d<t_nDMs_per_batch; d++){
-		sprintf(filename, "PSR_fft_data_%f.dat", t_dm_low + t_dm_step*(t_DM_shift + d));
-		size_t pos = d*t_nTSamplesFFT;
-		Export_data_to_file(&h_fft_input[pos], t_nTSamplesFFT, 1, filename);
-	}
-	printf("Exporting ddtr data to file...\n");
-	for(int d=0; d<t_nDMs_per_batch; d++){
-		sprintf(filename, "PSR_ddtr_data_%f.dat", t_dm_low + t_dm_step*(t_DM_shift + d));
-		size_t pos = d*t_nTimesamples;
-		Export_data_to_file(&h_ddtr_data[pos], t_nTimesamples, 1, filename);
-	}
-	
-	
-	// Create segments for de-redning
-	printf("Calculating segment sizes...\n");
-	int max_segment_length = 256;
-	int min_segment_length = 6;
-	std::vector<int> segment_sizes;
-	create_dered_segment_sizes_prefix_sum(&segment_sizes, min_segment_length, max_segment_length, t_nTSamplesFFT);
-	int nSegments = segment_sizes.size();
-	
-	// Calculate mean for segments and export_size
-	printf("Calculating MSD...\n");
-	size_t MSD_segmented_size_bytes = 2*nSegments*t_nDMs_per_batch*sizeof(float);
-	float *h_segmented_MSD;
-	h_segmented_MSD = (float*) malloc(MSD_segmented_size_bytes);
-	for(int d=0; d<t_nDMs_per_batch; d++){
-		for(int s=0; s<(nSegments - 1); s++){
-			size_t MSD_pos = d*nSegments + s;
-			double mean, stdev;
-			int range = segment_sizes[s + 1] - segment_sizes[s];
-			size_t pos = d*t_nTSamplesFFT + segment_sizes[s];
-			MSD_Kahan(&h_fft_power[pos], 1, range, 0, &mean, &stdev);
-			h_segmented_MSD[2*MSD_pos] = (float) mean;
-			h_segmented_MSD[2*MSD_pos + 1] = (float) stdev;
-		}
-		
-		sprintf(filename, "PSR_fft_data_means_%f.dat", t_dm_low + t_dm_step*(t_DM_shift + d));
-		Export_data_to_file((float2*) &h_segmented_MSD[d*nSegments], nSegments, 1, filename);
-	}
-	
-	// Calculate medians for segments
-	printf("Calculating median...\n");
-	size_t MED_segmented_size_bytes = nSegments*t_nDMs_per_batch*sizeof(float);
-	float *h_segmented_MED;
-	h_segmented_MED = (float*) malloc(MED_segmented_size_bytes);
-	for(int d=0; d<t_nDMs_per_batch; d++){
-		for(int s=0; s<(nSegments - 1); s++){
-			size_t MED_pos = d*nSegments + s;
-			int range = segment_sizes[s + 1] - segment_sizes[s];
-			size_t pos = d*t_nTSamplesFFT + segment_sizes[s];
-			h_segmented_MED[MED_pos] = Calculate_median(&h_fft_power[pos], range);
-		}
-		
-		sprintf(filename, "PSR_fft_data_median_%f.dat", t_dm_low + t_dm_step*(t_DM_shift + d));
-		Export_data_to_file(&h_segmented_MED[d*nSegments], nSegments, 1, filename);
-	}
-	
-	// Calculate medians for segments based on presto
-	printf("Calculating median using presto...\n");
-	float *h_segmented_MED_p;
-	h_segmented_MED_p = (float*) malloc(MED_segmented_size_bytes);
-	for(int d=0; d<t_nDMs_per_batch; d++){
-		for(int s=0; s<(nSegments - 1); s++){
-			size_t MED_pos = d*nSegments + s;
-			int range = segment_sizes[s + 1] - segment_sizes[s];
-			size_t pos = d*t_nTSamplesFFT + segment_sizes[s];
-			h_segmented_MED_p[MED_pos] = median(&h_fft_power[pos], range);
-		}
-		
-		sprintf(filename, "PSR_fft_data_median_p_%f.dat", t_dm_low + t_dm_step*(t_DM_shift + d));
-		Export_data_to_file(&h_segmented_MED_p[d*nSegments], nSegments, 1, filename);
-	}
-	
-	// Deredning by presto
-	printf("De-redning...\n");
-	for(int d=0; d<t_nDMs_per_batch; d++){
-		float2 *presto_dered, *MSD_dered, *MED_dered;
-		presto_dered = new float2[t_nTSamplesFFT];
-		MSD_dered    = new float2[t_nTSamplesFFT];
-		MED_dered    = new float2[t_nTSamplesFFT];
-		for(int s=0; s<t_nTSamplesFFT; s++){
-			size_t pos = d*t_nTSamplesFFT + s;
-			presto_dered[s] = h_fft_input[pos];
-			MSD_dered[s]    = h_fft_input[pos];
-			MED_dered[s]    = h_fft_input[pos];
-		}
-		size_t MSD_pos = d*nSegments;
-		presto_dered_sig(presto_dered, t_nTSamplesFFT);
-		dered_with_MSD(MSD_dered, t_nTSamplesFFT, segment_sizes.data(), nSegments, (float*) &h_segmented_MSD[MSD_pos]);
-		dered_with_MED(MED_dered, t_nTSamplesFFT, segment_sizes.data(), nSegments, &h_segmented_MED[MSD_pos]);
-		sprintf(filename, "PSR_fft_dered_%f.dat", t_dm_low + t_dm_step*(t_DM_shift + d));
-		Export_data_to_file(presto_dered, MSD_dered, MED_dered, t_nTSamplesFFT, filename);
-	}
-	
-	free(h_fft_input);
-	free(h_fft_power);
-	free(h_segmented_MSD);
-	free(h_segmented_MED);
-	#endif
-	
+    
+    
+    #ifdef CPU_SPECTRAL_WHITENING_DEBUG
+    CPU_spectral_whitening(d_FFT_complex_output, d_dedispersed_data, Prange->range.dm_step, Prange->range.dm_low, t_nTSamplesFFT, t_nDMs_per_batch, t_DM_shift);
+    #endif
+    
     //---------> Spectrum whitening
     timer.Start();
     cudaStream_t stream; stream = NULL;
@@ -1033,26 +458,26 @@ void checkCudaErrors( cudaError_t CUDA_error){
     time_log.adding("PSR","spectrum whitening",timer.Elapsed());
     (*compute_time) = (*compute_time) + timer.Elapsed();
     //---------<
-	
-	#ifdef CPU_SPECTRAL_WHITENING_DEBUG
-	printf("Data copied and power calculation...\n");
-	h_fft_input = (float2*) malloc(fft_input_size_bytes);
-	err = cudaMemcpy(h_fft_input, d_FFT_complex_output, fft_input_size_bytes, cudaMemcpyDeviceToHost);
-	if(err != cudaSuccess) printf("CUDA error\n");
-	// Export data to file
-	printf("Exporting fft data to file...\n");
-	for(int d=0; d<t_nDMs_per_batch; d++){
-		sprintf(filename, "PSR_fft_data_GPU_dered_%f.dat", t_dm_low + t_dm_step*(t_DM_shift + d));
-		size_t pos = d*t_nTSamplesFFT;
-		Export_data_to_file(&h_fft_input[pos], t_nTSamplesFFT, 1, filename);
-		printf(".");
-		fflush(stdout);
-	}
-	printf(" Finished!\n");
-	free(h_fft_input);
-	#endif
-	
-	
+    
+    #ifdef CPU_SPECTRAL_WHITENING_DEBUG
+    printf("Data copied and power calculation...\n");
+    h_fft_input = (float2*) malloc(fft_input_size_bytes);
+    err = cudaMemcpy(h_fft_input, d_FFT_complex_output, fft_input_size_bytes, cudaMemcpyDeviceToHost);
+    if(err != cudaSuccess) printf("CUDA error\n");
+    // Export data to file
+    printf("Exporting fft data to file...\n");
+    for(int d=0; d<t_nDMs_per_batch; d++){
+        sprintf(filename, "PSR_fft_data_GPU_dered_%f.dat", t_dm_low + t_dm_step*(t_DM_shift + d));
+        size_t pos = d*t_nTSamplesFFT;
+        Export_data_to_file(&h_fft_input[pos], t_nTSamplesFFT, 1, filename);
+        printf(".");
+        fflush(stdout);
+    }
+    printf(" Finished!\n");
+    free(h_fft_input);
+    #endif
+    
+    
     //---------> Calculate powers and interbinning
     timer.Start();
     //simple_power_and_interbin( (float2 *) d_two_B, d_half_C, d_one_A, nTimesamples, t_nDMs_per_batch);
@@ -1061,38 +486,14 @@ void checkCudaErrors( cudaError_t CUDA_error){
     time_log.adding("PSR","power spectrum",timer.Elapsed());
     (*compute_time) = (*compute_time) + timer.Elapsed();
     //---------<
-	
-	#ifdef CPU_POWER_AND_INTERBIN_DEBUG
-	printf("Data from power and interbin copied...\n");
-	size_t power_and_interbin_size_bytes = (t_nTimesamples>>1)*t_nDMs_per_batch*sizeof(float);
-	float *h_power_output;
-	h_power_output = (float*) malloc(power_and_interbin_size_bytes);
-	cudaError_t perr;
-	perr = cudaMemcpy(h_power_output, d_frequency_power, power_and_interbin_size_bytes, cudaMemcpyDeviceToHost);
-	if(perr != cudaSuccess) printf("CUDA error\n");
-	// Export data to file
-	char power_filename[300];
-	printf("Exporting fft data to file...\n");
-	for(int d=0; d<t_nDMs_per_batch; d++){
-		float t_dm_step         = Prange->range.dm_step;
-		float t_dm_low          = Prange->range.dm_low;
-		sprintf(power_filename, "PSR_power_data_%f.dat", t_dm_low + t_dm_step*(t_DM_shift + d));
-		size_t pos = d*(t_nTimesamples>>1);
-		Export_data_to_file(&h_power_output[pos], (t_nTimesamples>>1), 1, power_filename);
-		printf(".");
-		fflush(stdout);
-	}
-	printf(" Finished!\n");
-	free(h_power_output);
-	#endif
-
-	
+    
+    
     //---------> Mean and StDev on powers
     timer.Start();
     bool perform_continuous = false;
 
     double total_time, dit_time, MSD_time;
-    MSD_plane_profile(gmem->d_MSD, d_frequency_power, gmem->d_previous_partials, d_MSD_workarea, true, (t_nTimesamples>>1), t_nDMs_per_batch, h_boxcar_widths, 0, 0, 0, per_param.sigma_constant(), per_param.enable_msd_baseline_noise(), perform_continuous, &total_time, &dit_time, &MSD_time);
+    MSD_plane_profile(gmem->d_MSD, d_frequency_power, gmem->d_previous_partials, d_MSD_workarea, true, (t_nTimesamples>>1), t_nDMs_per_batch, h_boxcar_widths, 0, 0, 0, PSR_strategy.sigma_outlier_rejection_threshold(), PSR_strategy.enable_outlier_rejection(), perform_continuous, &total_time, &dit_time, &MSD_time);
     //printf("    MSD time: Total: %f ms; DIT: %f ms; MSD: %f ms;\n", total_time, dit_time, MSD_time);
     
     timer.Stop();
@@ -1111,26 +512,26 @@ void checkCudaErrors( cudaError_t CUDA_error){
         //---------<
         
         //---------> Simple harmonic summing
-        periodicity_simple_harmonic_summing(d_frequency_power_CT, d_power_SNR, gmem->d_power_harmonics, gmem->d_MSD, (t_nTimesamples>>1), t_nDMs_per_batch, per_param.nHarmonics());
-        periodicity_simple_harmonic_summing(d_frequency_interbin_CT, d_interbin_SNR, gmem->d_interbin_harmonics, gmem->d_MSD, t_nTimesamples, t_nDMs_per_batch, per_param.nHarmonics());
+        periodicity_simple_harmonic_summing(d_frequency_power_CT, d_power_SNR, gmem->d_power_harmonics, gmem->d_MSD, (t_nTimesamples>>1), t_nDMs_per_batch, PSR_strategy.nHarmonics());
+        periodicity_simple_harmonic_summing(d_frequency_interbin_CT, d_interbin_SNR, gmem->d_interbin_harmonics, gmem->d_MSD, t_nTimesamples, t_nDMs_per_batch, PSR_strategy.nHarmonics());
         //---------<
     }
     else if(harmonic_sum_algorithm == 1) {
         //---------> Greedy harmonic summing
-        periodicity_greedy_harmonic_summing(d_frequency_power, d_power_SNR, gmem->d_power_harmonics, gmem->d_MSD, (t_nTimesamples>>1), t_nDMs_per_batch, per_param.nHarmonics(), enable_scalloping_loss_removal);
-        periodicity_greedy_harmonic_summing(d_frequency_interbin, d_interbin_SNR, gmem->d_interbin_harmonics, gmem->d_MSD, t_nTimesamples, t_nDMs_per_batch, per_param.nHarmonics(), enable_scalloping_loss_removal);
+        periodicity_greedy_harmonic_summing(d_frequency_power, d_power_SNR, gmem->d_power_harmonics, gmem->d_MSD, (t_nTimesamples>>1), t_nDMs_per_batch, PSR_strategy.nHarmonics(), enable_scalloping_loss_removal);
+        periodicity_greedy_harmonic_summing(d_frequency_interbin, d_interbin_SNR, gmem->d_interbin_harmonics, gmem->d_MSD, t_nTimesamples, t_nDMs_per_batch, PSR_strategy.nHarmonics(), enable_scalloping_loss_removal);
         //---------<
     }
     else if(harmonic_sum_algorithm == 2) {
         //---------> PRESTO plus harmonic summing
-        periodicity_presto_plus_harmonic_summing(d_frequency_power, d_power_SNR, gmem->d_power_harmonics, gmem->d_MSD, (t_nTimesamples>>1), t_nDMs_per_batch, per_param.nHarmonics(), enable_scalloping_loss_removal);
-        periodicity_presto_plus_harmonic_summing(d_frequency_interbin, d_interbin_SNR, gmem->d_interbin_harmonics, gmem->d_MSD, t_nTimesamples, t_nDMs_per_batch, per_param.nHarmonics(), enable_scalloping_loss_removal);
+        periodicity_presto_plus_harmonic_summing(d_frequency_power, d_power_SNR, gmem->d_power_harmonics, gmem->d_MSD, (t_nTimesamples>>1), t_nDMs_per_batch, PSR_strategy.nHarmonics(), enable_scalloping_loss_removal);
+        periodicity_presto_plus_harmonic_summing(d_frequency_interbin, d_interbin_SNR, gmem->d_interbin_harmonics, gmem->d_MSD, t_nTimesamples, t_nDMs_per_batch, PSR_strategy.nHarmonics(), enable_scalloping_loss_removal);
         //---------<
     }
     else if(harmonic_sum_algorithm == 3) {
         //---------> PRESTO harmonic summing
-        periodicity_presto_harmonic_summing(d_frequency_power, d_power_SNR, gmem->d_power_harmonics, gmem->d_MSD, (t_nTimesamples>>1), t_nDMs_per_batch, per_param.nHarmonics(), enable_scalloping_loss_removal);
-        periodicity_presto_harmonic_summing(d_frequency_interbin, d_interbin_SNR, gmem->d_interbin_harmonics, gmem->d_MSD, t_nTimesamples, t_nDMs_per_batch, per_param.nHarmonics(), enable_scalloping_loss_removal);
+        periodicity_presto_harmonic_summing(d_frequency_power, d_power_SNR, gmem->d_power_harmonics, gmem->d_MSD, (t_nTimesamples>>1), t_nDMs_per_batch, PSR_strategy.nHarmonics(), enable_scalloping_loss_removal);
+        periodicity_presto_harmonic_summing(d_frequency_interbin, d_interbin_SNR, gmem->d_interbin_harmonics, gmem->d_MSD, t_nTimesamples, t_nDMs_per_batch, PSR_strategy.nHarmonics(), enable_scalloping_loss_removal);
         //---------<
     }
     timer.Stop();
@@ -1138,49 +539,26 @@ void checkCudaErrors( cudaError_t CUDA_error){
     time_log.adding("PSR","harmonic sum",timer.Elapsed());
     (*compute_time) = (*compute_time) + timer.Elapsed();
     //---------<
-	
-	
-	#ifdef CPU_SNR_DEBUG
-	printf("Data from power and interbin copied...\n");
-	size_t power_and_interbin_size_bytes = (t_nTimesamples>>1)*t_nDMs_per_batch*sizeof(float);
-	float *h_SNR_output;
-	h_SNR_output = (float*) malloc(power_and_interbin_size_bytes);
-	cudaError_t perr;
-	perr = cudaMemcpy(h_SNR_output, d_power_SNR, power_and_interbin_size_bytes, cudaMemcpyDeviceToHost);
-	if(perr != cudaSuccess) printf("CUDA error\n");
-	// Export data to file
-	char power_filename[300];
-	printf("Exporting fft data to file...\n");
-	for(int d=0; d<t_nDMs_per_batch; d++){
-		sprintf(power_filename, "PSR_SNR_data_%f.dat", t_dm_low + t_dm_step*(t_DM_shift + d));
-		size_t pos = d*(t_nTimesamples>>1);
-		Export_data_to_file(&h_SNR_output[pos], (t_nTimesamples>>1), 1, power_filename);
-		printf(".");
-		fflush(stdout);
-	}
-	printf(" Finished!\n");
-	free(h_SNR_output);
-	#endif
     
     
     //---------> Peak finding
     timer.Start();
-    if(per_param.candidate_algorithm()){
+    if(PSR_strategy.candidate_selection_algorithm()==1){
         //-------------- Thresholding
         if(harmonic_sum_algorithm == 0){
-            Threshold_for_periodicity_transposed(d_power_SNR, gmem->d_power_harmonics, d_power_list, gmem->gmem_power_peak_pos, gmem->d_MSD, per_param.sigma_cutoff(), t_nDMs_per_batch, (t_nTimesamples>>1), t_DM_shift, t_inBin, local_max_list_size);
-            Threshold_for_periodicity_transposed(d_interbin_SNR, gmem->d_interbin_harmonics, d_interbin_list, gmem->gmem_interbin_peak_pos, gmem->d_MSD, per_param.sigma_cutoff(), t_nDMs_per_batch, t_nTimesamples, t_DM_shift, t_inBin, local_max_list_size);
+            Threshold_for_periodicity_transposed(d_power_SNR, gmem->d_power_harmonics, d_power_list, gmem->gmem_power_peak_pos, gmem->d_MSD, PSR_strategy.sigma_cutoff(), t_nDMs_per_batch, (t_nTimesamples>>1), t_DM_shift, t_inBin, local_max_list_size);
+            Threshold_for_periodicity_transposed(d_interbin_SNR, gmem->d_interbin_harmonics, d_interbin_list, gmem->gmem_interbin_peak_pos, gmem->d_MSD, PSR_strategy.sigma_cutoff(), t_nDMs_per_batch, t_nTimesamples, t_DM_shift, t_inBin, local_max_list_size);
         }
         else {
-            Threshold_for_periodicity_normal(d_power_SNR, gmem->d_power_harmonics, d_power_list, gmem->gmem_power_peak_pos, gmem->d_MSD, per_param.sigma_cutoff(), (t_nTimesamples>>1), t_nDMs_per_batch, t_DM_shift, t_inBin, local_max_list_size);
-            Threshold_for_periodicity_normal(d_interbin_SNR, gmem->d_interbin_harmonics, d_interbin_list, gmem->gmem_interbin_peak_pos, gmem->d_MSD, per_param.sigma_cutoff(), t_nTimesamples, t_nDMs_per_batch, t_DM_shift, t_inBin, local_max_list_size);
+            Threshold_for_periodicity_normal(d_power_SNR, gmem->d_power_harmonics, d_power_list, gmem->gmem_power_peak_pos, gmem->d_MSD, PSR_strategy.sigma_cutoff(), (t_nTimesamples>>1), t_nDMs_per_batch, t_DM_shift, t_inBin, local_max_list_size);
+            Threshold_for_periodicity_normal(d_interbin_SNR, gmem->d_interbin_harmonics, d_interbin_list, gmem->gmem_interbin_peak_pos, gmem->d_MSD, PSR_strategy.sigma_cutoff(), t_nTimesamples, t_nDMs_per_batch, t_DM_shift, t_inBin, local_max_list_size);
         }
         //-------------- Thresholding
     }
     else {
         //-------------- Peak finding
-        Peak_find_for_periodicity_search(d_power_SNR, gmem->d_power_harmonics, d_power_list, (t_nTimesamples>>1), t_nDMs_per_batch, per_param.sigma_cutoff(), local_max_list_size, gmem->gmem_power_peak_pos, gmem->d_MSD, t_DM_shift, t_inBin, transposed_data);
-        Peak_find_for_periodicity_search(d_interbin_SNR, gmem->d_interbin_harmonics, d_interbin_list, t_nTimesamples, t_nDMs_per_batch, per_param.sigma_cutoff(), local_max_list_size, gmem->gmem_interbin_peak_pos, gmem->d_MSD, t_DM_shift, t_inBin, transposed_data);
+        Peak_find_for_periodicity_search(d_power_SNR, gmem->d_power_harmonics, d_power_list, (t_nTimesamples>>1), t_nDMs_per_batch, PSR_strategy.sigma_cutoff(), local_max_list_size, gmem->gmem_power_peak_pos, gmem->d_MSD, t_DM_shift, t_inBin, transposed_data);
+        Peak_find_for_periodicity_search(d_interbin_SNR, gmem->d_interbin_harmonics, d_interbin_list, t_nTimesamples, t_nDMs_per_batch, PSR_strategy.sigma_cutoff(), local_max_list_size, gmem->gmem_interbin_peak_pos, gmem->d_MSD, t_DM_shift, t_inBin, transposed_data);
         //-------------- Peak finding
     }
     timer.Stop();
@@ -1188,8 +566,7 @@ void checkCudaErrors( cudaError_t CUDA_error){
     time_log.adding("PSR","candidates",timer.Elapsed());
     (*compute_time) = (*compute_time) + timer.Elapsed();
     //---------<
-	
-    //checkCudaErrors(cudaGetLastError());
+    
   }
 
   void Export_Data_To_File(std::vector<Candidate_List> candidates, const char *filename) {
@@ -1219,102 +596,73 @@ void checkCudaErrors( cudaError_t CUDA_error){
 
 
   /** \brief Function that performs a GPU periodicity search. */
-  void GPU_periodicity(int nRanges, int processed, float sigma_cutoff, float ***output_buffer, int const*const ndms, int *inBin, float *dm_low, float *dm_high, float *dm_step, float tsamp, int nHarmonics, bool candidate_algorithm, bool enable_msd_baseline_noise, float OR_sigma_multiplier) {
-    // processed = maximum number of time-samples through out all ranges
-    // nTimesamples = number of time-samples in given range 'i'
-    
+  void GPU_periodicity(aa_periodicity_strategy &PSR_strategy, float ***output_buffer) {
     TimeLog time_log;
     
     LOG(log_level::notice, "------------ STARTING PERIODICITY SEARCH ------------");
-
-    // Creating periodicity parameters object (temporary, it should be moved elsewhere)
-    aa_periodicity_plan per_param_plan(sigma_cutoff, OR_sigma_multiplier, nHarmonics, 0, candidate_algorithm, enable_msd_baseline_noise); // \warning The periodicity plan uses a hardcoded number (this also used to be the case for the (now deprecated) Periodicity_parameters class.
-    aa_periodicity_strategy per_param(per_param_plan);
-    per_param.print_info(per_param);
-	
-    std::vector<int> h_boxcar_widths; h_boxcar_widths.resize(nHarmonics); 
-    for(int f=0; f<nHarmonics; f++) h_boxcar_widths[f]=f+1;
-	
-    // Creating DDrange vector (temporary, it should be moved elsewhere)
-    Dedispersion_Plan DD_plan;
-    Create_DD_plan(&DD_plan, nRanges, dm_low, dm_high, dm_step, inBin, processed, ndms, tsamp);
-    DD_plan.print();
+    
     
     // Determining available memory (temporary, it should be moved elsewhere)
     size_t memory_available,total_mem;
     cudaMemGetInfo(&memory_available,&total_mem);
-	
-	
-    //----------------------------------------------------------------------------
-    //----------- Finding Periodicity plan
-    bool plan_finished;
-    int max_nDMs_in_memory;
-    AA_Periodicity_Plan P_plan;
-    P_plan.nHarmonics = nHarmonics;
-    plan_finished = Find_Periodicity_Plan(&max_nDMs_in_memory, &P_plan, &DD_plan, memory_available);
-    if(plan_finished == false) return;
     
-    size_t input_plane_size = P_plan.input_plane_size;
-    #ifdef GPU_PERIODICITY_SEARCH_DEBUG
-        P_plan.print();
-    #endif
+    std::vector<int> h_boxcar_widths; h_boxcar_widths.resize(PSR_strategy.nHarmonics()); 
+    for(int f=0; f<PSR_strategy.nHarmonics(); f++) h_boxcar_widths[f]=f+1;
     
     //--------> Allocation of GPU memory
     GPU_Memory_for_Periodicity_Search GPU_memory;
-    GPU_memory.Allocate(&P_plan);
-	
-    float h_MSD[P_plan.nHarmonics*2];
+    GPU_memory.Allocate(PSR_strategy);
+    
+    float h_MSD[PSR_strategy.nHarmonics()*2];
     //----------------------------<
-	
+    
     // Timing
     double Total_periodicity_time = 0, Total_calc_time = 0, calc_time_per_range = 0, Total_copy_time = 0, copy_time_per_range = 0;
     aa_gpu_timer timer, periodicity_timer;
-	
+    
     periodicity_timer.Start();
-	
+    
     LOG(log_level::notice, "------ CONFIGURATION OF PERIODICITY SEARCH DONE -----");
     //---------------------------------------------------------------
     //---------------------------------------------------------------
-    for(int p=0; p<(int) P_plan.inBin_group.size(); p++) {
-      std::vector<Candidate_List> PowerCandidates;
-      std::vector<Candidate_List> InterbinCandidates;
+    
+    
+    for(int r=0; r<(int) PSR_strategy.nRanges(); r++) {
+        aa_periodicity_range current_p_range = PSR_strategy.get_periodicity_range(r);
+        std::vector<Candidate_List> PowerCandidates;
+        std::vector<Candidate_List> InterbinCandidates;
 
-      GPU_memory.Reset_MSD();
-		
-
-      for(int r=0; r<(int) P_plan.inBin_group[p].Prange.size(); r++) {
-        P_plan.inBin_group[p].Prange[r].print();
+        GPU_memory.Reset_MSD();
+        current_p_range.print();
         
-        for(int b=0; b<(int)P_plan.inBin_group[p].Prange[r].batches.size(); b++) {
-          P_plan.inBin_group[p].Prange[r].batches[b].print(b);
-	
-          GPU_memory.Reset_Candidate_List();
-		  
-		  checkCudaErrors(cudaGetLastError());
-	
-          //---------> Copy input data to the device
-          timer.Start();
-          Copy_data_for_periodicity_search(GPU_memory.d_one_A, output_buffer[P_plan.inBin_group[p].Prange[r].rangeid], &P_plan.inBin_group[p].Prange[r].batches[b]);
-          timer.Stop();
-          time_log.adding("PSR","Host-To-Device",timer.Elapsed());
-          copy_time_per_range = copy_time_per_range + timer.Elapsed();
-          //---------<
+        for(int b=0; b<(int) current_p_range.batches.size(); b++) {
+            current_p_range.batches[b].print(b);
+            
+            GPU_memory.Reset_Candidate_List();
+            
+            //---------> Copy input data to the device
+            timer.Start();
+            Copy_data_for_periodicity_search(GPU_memory.d_one_A, output_buffer[current_p_range.rangeid], &current_p_range.batches[b]);
+            timer.Stop();
+            time_log.adding("PSR","Host-To-Device",timer.Elapsed());
+            copy_time_per_range = copy_time_per_range + timer.Elapsed();
+            //---------<
 
           // simple harmonic sum 0
           // greedy harmonic sum 1
           // presto plus harmonic sum 2
           // presto harmonic sum 3
-          int harmonic_sum_algorithm = 1;
-          bool enable_scalloping_loss_removal = true;
+          int harmonic_sum_algorithm = PSR_strategy.harmonic_sum_algorithm();
+          bool enable_scalloping_loss_removal = PSR_strategy.enable_scalloping_loss_mitigation();
           
           //---------> Periodicity search
-          Periodicity_search(&GPU_memory, per_param, &calc_time_per_range, input_plane_size, &P_plan.inBin_group[p].Prange[r], &P_plan.inBin_group[p].Prange[r].batches[b], &h_boxcar_widths, harmonic_sum_algorithm, enable_scalloping_loss_removal);
+          Periodicity_search(&GPU_memory, PSR_strategy, &calc_time_per_range, PSR_strategy.input_plane_size(), &current_p_range, &current_p_range.batches[b], &h_boxcar_widths, harmonic_sum_algorithm, enable_scalloping_loss_removal);
           //---------<
-	
+    
           //---------> Copy candidates to the host
           timer.Start();
-	
-		  cudaError_t e;
+    
+          cudaError_t e;
           int last_entry;
           int nPowerCandidates = GPU_memory.Get_Number_of_Power_Candidates();
           PowerCandidates.push_back(*(new Candidate_List(r)));
@@ -1322,93 +670,69 @@ void checkCudaErrors( cudaError_t CUDA_error){
           LOG(log_level::debug, " PSR: Total number of candidates found in this range is " + std::to_string(nPowerCandidates) + ";");
           PowerCandidates[last_entry].Allocate(nPowerCandidates);
           if(harmonic_sum_algorithm==0) {
-			e = cudaMemcpy( &PowerCandidates[last_entry].list[0], &GPU_memory.d_two_B[0], nPowerCandidates*Candidate_List::el*sizeof(float), cudaMemcpyDeviceToHost);
-		  }
+              e = cudaMemcpy( &PowerCandidates[last_entry].list[0], &GPU_memory.d_two_B[0], nPowerCandidates*Candidate_List::el*sizeof(float), cudaMemcpyDeviceToHost);
+          }
           else {
-			  e = cudaMemcpy( &PowerCandidates[last_entry].list[0], GPU_memory.d_half_C, nPowerCandidates*Candidate_List::el*sizeof(float), cudaMemcpyDeviceToHost);
-		  }
-	  
+              e = cudaMemcpy( &PowerCandidates[last_entry].list[0], GPU_memory.d_half_C, nPowerCandidates*Candidate_List::el*sizeof(float), cudaMemcpyDeviceToHost);
+          }
+      
           if(e != cudaSuccess) {
             LOG(log_level::error, "Could not cudaMemcpy in aa_device_periods.cu (" + std::string(cudaGetErrorString(e)) + ")");
           }
-	
+    
           int nInterbinCandidates = GPU_memory.Get_Number_of_Interbin_Candidates();
           InterbinCandidates.push_back(*(new Candidate_List(r)));
           last_entry = InterbinCandidates.size()-1;
           LOG(log_level::debug, " PSR with inter-binning: Total number of candidates found in this range is " + std::to_string(nInterbinCandidates) + ";");
           InterbinCandidates[last_entry].Allocate(nInterbinCandidates);
           if(harmonic_sum_algorithm==0) {
-			  e = cudaMemcpy( &InterbinCandidates[last_entry].list[0], &GPU_memory.d_two_B[input_plane_size], nInterbinCandidates*Candidate_List::el*sizeof(float), cudaMemcpyDeviceToHost);
-		  }
-		  else {
-			e = cudaMemcpy( &InterbinCandidates[last_entry].list[0], GPU_memory.d_one_A, nInterbinCandidates*Candidate_List::el*sizeof(float), cudaMemcpyDeviceToHost);
-		  }
-	  
+              e = cudaMemcpy( &InterbinCandidates[last_entry].list[0], &GPU_memory.d_two_B[PSR_strategy.input_plane_size()], nInterbinCandidates*Candidate_List::el*sizeof(float), cudaMemcpyDeviceToHost);
+          }
+          else {
+            e = cudaMemcpy( &InterbinCandidates[last_entry].list[0], GPU_memory.d_one_A, nInterbinCandidates*Candidate_List::el*sizeof(float), cudaMemcpyDeviceToHost);
+          }
+      
           if(e != cudaSuccess) {
             LOG(log_level::error, "Could not cudaMemcpy in aa_device_periods.cu (" + std::string(cudaGetErrorString(e)) + ")");
           }
-	  
+      
           timer.Stop();
           time_log.adding("PSR","Device-To-Host",timer.Elapsed());
           copy_time_per_range = copy_time_per_range + timer.Elapsed();
           //---------<
-	
+    
           GPU_memory.Get_MSD(h_MSD);
-	
-          PowerCandidates[last_entry].Process(h_MSD, &P_plan.inBin_group[p],  1.0);
-          InterbinCandidates[last_entry].Process(h_MSD, &P_plan.inBin_group[p], 2.0);
-	
-          //printf("\n");
-        } //batches
-
-      } // ranges
-
-//    #ifdef PS_REUSE_MSD_WITHIN_INBIN
-//      GPU_memory.Get_MSD(h_MSD);
-//      
-//      for(int f=0; f<(int)PowerCandidates.size(); f++) {
-//        PowerCandidates[f].Process(h_MSD, &P_plan.inBin_group[p], 1.0);
-//      }
-//      
-//      for(int f=0; f<(int)InterbinCandidates.size(); f++) {
-//        InterbinCandidates[f].Process(h_MSD, &P_plan.inBin_group[p], 2.0);
-//      }
-//    #endif
+    
+          PowerCandidates[last_entry].Process(h_MSD, &current_p_range,  1.0);
+          InterbinCandidates[last_entry].Process(h_MSD, &current_p_range, 2.0);
+      } //batches
 
       // Export of the candidate list for inBin range;
       char filename[100];
-      float range_dm_low  = P_plan.inBin_group[p].Prange[0].range.dm_low;
-      float range_dm_high = P_plan.inBin_group[p].Prange[P_plan.inBin_group[p].Prange.size()-1].range.dm_high; 
+      float range_dm_low  = current_p_range.range.dm_low();
+      float range_dm_high = current_p_range.range.dm_high(); 
       sprintf(filename, "fourier-dm_%.2f-%.2f.dat", range_dm_low, range_dm_high);
       Export_Data_To_File(PowerCandidates, filename);
       sprintf(filename, "fourier_inter-dm_%.2f-%.2f.dat", range_dm_low, range_dm_high);
       Export_Data_To_File(InterbinCandidates, filename);
-		
+        
       // Cleanup
       for(int f=0; f<(int) PowerCandidates.size(); f++) PowerCandidates[f].list.clear();
       PowerCandidates.clear();
       for(int f=0; f<(int) InterbinCandidates.size(); f++) InterbinCandidates[f].list.clear();
       InterbinCandidates.clear();
-		
-		
-      //printf("     -----------------------\n");
-      //printf("     -> This range calculation time: %f ms\n", calc_time_per_range);
-      //printf("     -> This range copy time:        %f ms\n", copy_time_per_range);
-      //printf("\n");
+        
+        
       Total_calc_time = Total_calc_time + calc_time_per_range;
       calc_time_per_range = 0;
       Total_copy_time = Total_copy_time + copy_time_per_range;
       copy_time_per_range = 0;
     } // inBin ranges
     printf("-----------------------------------------------------------------------------------\n");
-	
+    
     periodicity_timer.Stop();
     Total_periodicity_time = periodicity_timer.Elapsed();
     time_log.adding("PSR","total",Total_periodicity_time);
-    //printf("\nTimer:\n");
-    //printf("Total calculation time: %f ms\n", Total_calc_time);
-    //printf("Total copy time:        %f ms\n", Total_copy_time);
-    //printf("Total periodicity time: %f ms\n", Total_periodicity_time);	
 
     cudaDeviceSynchronize();
   };

--- a/src/aa_device_periods.cu
+++ b/src/aa_device_periods.cu
@@ -234,12 +234,12 @@ namespace astroaccelerate {
       int size = (int)batches.size();
 	  int batchDM_0 = batches[0].nDMs_per_batch;
       //printf("  De-dispersion range: %f--%f:%f inBin:%d; nTimesamples:%d; nDMs:%d;\n", range.dm_low, range.dm_high, range.dm_step, range.inBin, range.nTimesamples, range.nDMs);
-      LOG(log_level::notice, "-> De-dispersion range:" + std::to_string(range.dm_low) + "--" + std::to_string(range.dm_high) + ":" + std::to_string(range.dm_step) + "; Binning:" + std::to_string(range.inBin) + "; nTimesamples:" + std::to_string(range.nTimesamples) + "; nDMs:" + std::to_string(range.nDMs) + ";");
+      LOG(log_level::notice, "De-dispersion range:" + std::to_string(range.dm_low) + "--" + std::to_string(range.dm_high) + ":" + std::to_string(range.dm_step) + "; Binning:" + std::to_string(range.inBin) + "; nTimesamples:" + std::to_string(range.nTimesamples) + "; nDMs:" + std::to_string(range.nDMs) + ";");
       if(size>1) {
         int batchDM_last = batches[size-1].nDMs_per_batch;
-        LOG(log_level::notice, "-> De-dispersion range will be processed in " + std::to_string(size) + " batches each containing " + std::to_string(batchDM_0) + " DM trials with tail of " + std::to_string(batchDM_last) + " DM trials");
+        LOG(log_level::debug, "-> De-dispersion range will be processed in " + std::to_string(size) + " batches each containing " + std::to_string(batchDM_0) + " DM trials with tail of " + std::to_string(batchDM_last) + " DM trials");
       }
-      else LOG(log_level::notice, "-> Periodicity search will run 1 batch containing " + std::to_string(batchDM_0) + " DM trials.");
+      else LOG(log_level::debug, "-> Periodicity search will run 1 batch containing " + std::to_string(batchDM_0) + " DM trials.");
       float MSD_block_mem = (total_MSD_blocks*MSD_PARTIAL_SIZE*sizeof(float))/(1024.0*1024.0);
       LOG(log_level::debug, "-> Total number of MSD blocks is " + std::to_string(total_MSD_blocks) + " which is " + std::to_string(MSD_block_mem) + "MB");
       #ifdef GPU_PERIODICITY_SEARCH_DEBUG
@@ -1312,7 +1312,7 @@ void checkCudaErrors( cudaError_t CUDA_error){
           int nPowerCandidates = GPU_memory.Get_Number_of_Power_Candidates();
           PowerCandidates.push_back(*(new Candidate_List(r)));
           last_entry = PowerCandidates.size()-1;
-          LOG(log_level::notice, " PSR: Total number of candidates found in this range is " + std::to_string(nPowerCandidates) + ";");
+          LOG(log_level::debug, " PSR: Total number of candidates found in this range is " + std::to_string(nPowerCandidates) + ";");
           PowerCandidates[last_entry].Allocate(nPowerCandidates);
           if(harmonic_sum_algorithm==0) {
 			e = cudaMemcpy( &PowerCandidates[last_entry].list[0], &GPU_memory.d_two_B[0], nPowerCandidates*Candidate_List::el*sizeof(float), cudaMemcpyDeviceToHost);
@@ -1328,7 +1328,7 @@ void checkCudaErrors( cudaError_t CUDA_error){
           int nInterbinCandidates = GPU_memory.Get_Number_of_Interbin_Candidates();
           InterbinCandidates.push_back(*(new Candidate_List(r)));
           last_entry = InterbinCandidates.size()-1;
-          LOG(log_level::notice, " PSR with inter-binning: Total number of candidates found in this range is " + std::to_string(nInterbinCandidates) + ";");
+          LOG(log_level::debug, " PSR with inter-binning: Total number of candidates found in this range is " + std::to_string(nInterbinCandidates) + ";");
           InterbinCandidates[last_entry].Allocate(nInterbinCandidates);
           if(harmonic_sum_algorithm==0) {
 			  e = cudaMemcpy( &InterbinCandidates[last_entry].list[0], &GPU_memory.d_two_B[input_plane_size], nInterbinCandidates*Candidate_List::el*sizeof(float), cudaMemcpyDeviceToHost);

--- a/src/aa_device_spectral_whitening.cu
+++ b/src/aa_device_spectral_whitening.cu
@@ -1,16 +1,50 @@
 #include <stdio.h>
 #include <cufft.h>
+#include <vector>
 #include "aa_params.hpp"
 #include "aa_device_spectrum_whitening_kernel.hpp"
+#include "aa_host_utilities.hpp"
+
+#include "aa_log.hpp"
 
 // define for debug info
-//#define POWER_DEBUG
+//#define AA_SPECTRAL_WHITENING_DEBUG
 
 //{{{ Dopler Stretch 
 
 namespace astroaccelerate {
 
-	void spectrum_whitening_SGP1(float *d_input, unsigned long int nSamples, int nDMs, cudaStream_t &stream){
+	void create_dered_segment_sizes_prefix_sum(std::vector<int> *segment_sizes, int min_segment_length, int max_segment_length, size_t nSamples){
+		segment_sizes->push_back(0);
+		
+		int seg_length = min_segment_length;
+		int seg_sum = 1 + seg_length;
+		segment_sizes->push_back(seg_sum);
+		
+		while( (size_t) (seg_sum + seg_length) < nSamples) {
+			seg_sum = seg_sum + seg_length;
+			seg_length = min_segment_length*log(seg_sum);
+			if(seg_length > max_segment_length) seg_length = max_segment_length;
+			segment_sizes->push_back(seg_sum);
+		}
+		segment_sizes->push_back(nSamples);
+	}
+	
+	void calculate_mean_for_segments(float *d_MSD_segments, float2 *d_input, size_t nSamples, int nDMs, int *d_segment_sizes, int nSegments, cudaStream_t &stream){
+		size_t smem_size = 0;
+		dim3 grid_size(nSegments, nDMs , 1);
+		dim3 block_size(256, 1, 1);
+		call_kernel_segmented_MSD(block_size, grid_size, smem_size, stream, d_MSD_segments, d_input, d_segment_sizes, nSamples, nSegments);
+	}
+	
+	void calculate_median_for_segments(float *d_MSD_segments, float2 *d_input, size_t nSamples, int nDMs, int *d_segment_sizes, int nSegments, cudaStream_t &stream){
+		size_t smem_size = 0;
+		dim3 grid_size(nSegments - 1, nDMs , 1);
+		dim3 block_size(128, 1, 1);
+		call_kernel_segmented_median(block_size, grid_size, smem_size, stream, d_MSD_segments, d_input, d_segment_sizes, nSamples, nSegments);
+	}
+
+	void spectrum_whitening_SGP1(float *d_input, size_t nSamples, int nDMs, cudaStream_t &stream){
 		dim3 grid_size((nSamples + 128 - 1)/128, nDMs , 1);
 		dim3 block_size(128, 1, 1);
 		call_kernel_spectrum_whitening_SGP1(
@@ -21,6 +55,66 @@ namespace astroaccelerate {
 			d_input, 
 			nSamples
 		);
+	}
+	
+	void spectrum_whitening_SGP2(float2 *d_input, size_t nSamples, int nDMs, bool enable_median, cudaStream_t &stream) {
+		int max_segment_length = 250;
+		int min_segment_length = 6;
+		
+		std::vector<int> segment_sizes; // must be a prefix sum!
+		create_dered_segment_sizes_prefix_sum(&segment_sizes, min_segment_length, max_segment_length, nSamples);
+		
+		//------------ Allocate and copy segment sizes to the GPU
+		int nSegments = segment_sizes.size();
+		size_t ss_size = nSegments*sizeof(int);
+		size_t ss_MSD_size = nSegments*sizeof(float)*nDMs;
+		int *d_segment_sizes;
+		if ( cudaSuccess != cudaMalloc((void **) &d_segment_sizes, ss_size )) {
+			printf("spectral whitening Allocation error! d_segment_sizes\n");
+		}
+		float *d_MSD_segments;
+		if ( cudaSuccess != cudaMalloc((void **) &d_MSD_segments, ss_MSD_size )) {
+			printf("spectral whitening Allocation error! d_MSD_segments\n");
+		}
+		cudaError_t e = cudaMemcpy(d_segment_sizes, segment_sizes.data(), ss_size, cudaMemcpyHostToDevice);
+		if(e != cudaSuccess) {
+			LOG(log_level::error, "Could not cudaMemcpy in aa_device_spectral_whitening.cu (" + std::string(cudaGetErrorString(e)) + ")");
+		}
+		
+		//------------ Calculate mean or median;
+		if(enable_median){
+			calculate_median_for_segments(d_MSD_segments, d_input, nSamples, nDMs, d_segment_sizes, nSegments, stream);
+		}
+		else {
+			calculate_mean_for_segments(d_MSD_segments, d_input, nSamples, nDMs, d_segment_sizes, nSegments, stream);
+		}
+		
+		#ifdef AA_SPECTRAL_WHITENING_DEBUG
+		float *h_segmented_MSD;
+		h_segmented_MSD = new float[nDMs*nSegments];
+		e = cudaMemcpy(h_segmented_MSD, d_MSD_segments, nDMs*nSegments*sizeof(float), cudaMemcpyDeviceToHost);
+		printf("Calculated means:\n");
+		char str[300];
+		for(int d=0; d<nDMs; d++){
+			if(enable_median){
+				sprintf(str, "PSR_fft_GPU_medians_%d.dat", d);
+			}
+			else {
+				sprintf(str, "PSR_fft_GPU_means_%d.dat", d);
+			}
+			Export_data_to_file(&h_segmented_MSD[d*nSegments], nSegments, 1, str);
+		}
+		delete[] h_segmented_MSD;
+		#endif
+		
+		//------------ Call kernel for spectral whitening
+		size_t smem_size = 0;
+		dim3 grid_size(nSegments, nDMs , 1);
+		dim3 block_size(256, 1, 1);
+		call_kernel_spectrum_whitening_SGP2(block_size, grid_size, smem_size, stream, d_MSD_segments, d_input, d_segment_sizes, nSamples, nSegments);
+		
+		cudaFree(d_segment_sizes);
+		cudaFree(d_MSD_segments);
 	}
 
 } //namespace astroaccelerate

--- a/src/aa_device_spectral_whitening_kernel.cu
+++ b/src/aa_device_spectral_whitening_kernel.cu
@@ -403,13 +403,13 @@ __global__ void GPU_kernel_spectrum_whitening_SGP2(float *d_segmented_MSD, float
 		float previous_mean = d_segmented_MSD[blockIdx.y*nSegments + blockIdx.x - 1]*1.44269504088896;
 		float current_mean  = d_segmented_MSD[blockIdx.y*nSegments + blockIdx.x]*1.44269504088896;
 		
-		int range = ((previous_range + current_range)>>1);
+		int range = ((previous_range + current_range + 1)>>1);
 		int i = range - threadIdx.x;
 		float slope = (current_mean - previous_mean) / ((float) range);
 		float norm  = 1.0/sqrt(previous_mean + slope*i);
 		int local_pos = fm1_pos + (previous_range>>1) + i;
 		
-		if( i >= 0 && i<=range && local_pos < nSamples){
+		if( i >= 0 && i<range && local_pos < nSamples){
 			size_t global_pos = blockIdx.y*nSamples + local_pos;
 			d_input[global_pos].x *= norm;
 			d_input[global_pos].y *= norm;

--- a/src/aa_device_spectral_whitening_kernel.cu
+++ b/src/aa_device_spectral_whitening_kernel.cu
@@ -1,10 +1,55 @@
+#include <iostream>
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include <cuda_runtime_api.h>
 #include <cufft.h>
 #include "aa_params.hpp"
 #include "aa_device_cuda_deprecated_wrappers.cuh"
 
 namespace astroaccelerate {
+
+class Sort_Params {
+public:
+	static const int warp = 32;
+	// search_exp = log_2(N) + 1
+};
+
+class Sort_64 : public Sort_Params {
+public:
+	static const int nThreads = 32;
+	static const int search_exp = 7;
+};
+
+class Sort_128 : public Sort_Params {
+public:
+	static const int nThreads = 64;
+	static const int search_exp = 8;
+};
+
+class Sort_256 : public Sort_Params {
+public:
+	static const int nThreads = 128;
+	static const int search_exp = 9;
+};
+
+class Sort_512 : public Sort_Params {
+public:
+	static const int nThreads = 256;
+	static const int search_exp = 10;
+};
+
+class Sort_1024 : public Sort_Params {
+public:
+	static const int nThreads = 512;
+	static const int search_exp = 11;
+};
+
+class Sort_2048 : public Sort_Params {
+public:
+	static const int nThreads = 1024;
+	static const int search_exp = 12;
+};
+
 
 __device__ __inline__ void Initiate(float *M, float *S, int *j, float element){
 	*M = element;
@@ -180,6 +225,52 @@ __device__ __inline__ void MSD_block_outlier_rejection(float *d_input, int *x_st
 	__syncthreads();
 }
 
+//--------------- Bitonic sort device functions -----------------
+
+template<typename intype>
+__device__ __inline__ void butterfly_exchange(intype *s_values, int butterfly_size, int sort_direction){
+	int block_size      = (1<<butterfly_size);
+	int block_size_half = (1<<(butterfly_size-1));
+	int local_block     = ((threadIdx.x)>>(butterfly_size-1));
+	int local_thread    = ((threadIdx.x)&(block_size_half-1));
+	
+	int elA, elB;
+	elA = local_block*block_size + local_thread;
+	elB = local_block*block_size + local_thread + (block_size>>1);
+	
+	if(sort_direction==0 && s_values[elA] > s_values[elB]){ // ascending
+		intype swap;
+		swap = s_values[elA];
+		s_values[elA] = s_values[elB];
+		s_values[elB] = swap;
+	}
+	if(sort_direction==1 && s_values[elA] < s_values[elB]){ // descending
+		intype swap;
+		swap = s_values[elA];
+		s_values[elA] = s_values[elB];
+		s_values[elB] = swap;
+	}
+}
+
+template<class const_params, typename intype>
+__device__ __inline__ void bitonic_sort_block(intype *s_values){
+	// major cycle
+	//     Consists of series of incrementally larger butterfly operations 
+	for(int majorc = 1; majorc<const_params::search_exp; majorc++){
+		int sort_dir_flag = (threadIdx.x>>(majorc-1))&1;
+		// minor cycle
+		//     Consists of series of butterfly operations of smaller and smaller size
+		//     until size of two
+		for(int minorc = majorc; minorc>0; minorc--){
+			butterfly_exchange(s_values, minorc, sort_dir_flag);
+			__syncthreads();
+		}
+	}
+}
+
+//--------------- Bitonic sort device functions -----------------
+
+
 
 __global__ void GPU_kernel_spectrum_whitening_SGP1(float *d_input, unsigned long int nSamples) {
 	__shared__ float s_par_MSD[256];
@@ -197,6 +288,145 @@ __global__ void GPU_kernel_spectrum_whitening_SGP1(float *d_input, unsigned long
 	d_input[gpos + spos + threadIdx.x] = (d_input[gpos + spos + threadIdx.x] - mean)/stdev;
 }
 
+
+__global__ void GPU_kernel_segmented_MSD(float *d_segmented_MSD, float2 *d_input, int *d_segment_sizes, size_t nSamples, int nSegments){
+	float M, S, ftemp;
+	int j, spos;
+	size_t gpos;
+	
+	int start_pos = d_segment_sizes[blockIdx.x];
+	int end_pos   = d_segment_sizes[blockIdx.x + 1];
+	int active_range = end_pos - start_pos;
+	
+	
+	M=0; S=0; j=0;
+	spos = threadIdx.x;
+	
+	//first iteration
+	gpos = blockIdx.y*nSamples + start_pos + spos;
+	if(spos < active_range){
+		ftemp = d_input[gpos].x*d_input[gpos].x + d_input[gpos].y*d_input[gpos].y;
+		if(blockIdx.x==0 && threadIdx.x==0){
+			ftemp = 0;
+		}
+		Initiate( &M, &S, &j, ftemp);
+	}
+	spos = spos + 32;
+	
+	__syncthreads();
+	
+	for(int i = 0; i < 7; i++){
+		if(spos < active_range){
+			gpos = blockIdx.y*nSamples + start_pos + spos;
+			ftemp = d_input[gpos].x*d_input[gpos].x + d_input[gpos].y*d_input[gpos].y;
+			Add_one( &M, &S, &j, ftemp);
+		}
+		spos = spos + 32;
+	}
+	
+	__syncthreads();
+	
+	Reduce_WARP( &M, &S, &j);
+	
+	if(threadIdx.x == 0){
+		d_segmented_MSD[blockIdx.y*nSegments  + blockIdx.x] = M / (double) j;
+		//d_segmented_MSD[blockIdx.y*nSegments  + 2*blockIdx.x + 1] = sqrt(S / (double) j);
+	}
+}
+
+template<class const_params>
+__global__ void GPU_kernel_segmented_median(float *d_segmented_MSD, float2 *d_input, int *d_segment_sizes, size_t nSamples, int nSegments){
+	__shared__ float s_values[2*const_params::nThreads];
+	s_values[threadIdx.x] = 0;
+	s_values[threadIdx.x + const_params::nThreads] = 0;
+	
+	int start_pos = d_segment_sizes[blockIdx.x];
+	int end_pos   = d_segment_sizes[blockIdx.x + 1];
+	int active_range = end_pos - start_pos;
+	if(active_range <= 0 && active_range > const_params::nThreads*2) return;
+	
+	int local_pos;
+	local_pos = start_pos + threadIdx.x;
+	if( threadIdx.x < active_range && local_pos < nSamples) {
+		float2 value = d_input[blockIdx.y*nSamples + local_pos];
+		s_values[threadIdx.x] = value.x*value.x + value.y*value.y;
+	}
+	if( (threadIdx.x + const_params::nThreads) < active_range && (local_pos +  + const_params::nThreads) < nSamples ) {
+		float2 value = d_input[blockIdx.y*nSamples + const_params::nThreads + local_pos];
+		s_values[const_params::nThreads + threadIdx.x] = value.x*value.x + value.y*value.y;
+	}
+	__syncthreads();
+	
+	bitonic_sort_block<const_params>(s_values);
+	
+	int nZeros = const_params::nThreads*2 - active_range;
+	int median_pos = nZeros + (active_range>>1);
+	
+	if( threadIdx.x == 0 ){
+		if( (active_range&1)==0 ){ // even
+			float median = (s_values[median_pos] + s_values[median_pos + 1])*0.5f;
+			d_segmented_MSD[blockIdx.y*nSegments  + blockIdx.x] = median;
+		}
+		else {
+			float median = s_values[median_pos];
+			d_segmented_MSD[blockIdx.y*nSegments  + blockIdx.x] = median;
+		}
+	}
+}
+
+
+__global__ void GPU_kernel_spectrum_whitening_SGP2(float *d_segmented_MSD, float2 *d_input, int *d_segment_sizes, size_t nSamples, int nSegments){
+	if(blockIdx.x==0){
+		// First segment cannot calculate slope thus it is normalized by mean only
+		int f0_pos = d_segment_sizes[blockIdx.x + 0];
+		int fp1_pos = d_segment_sizes[blockIdx.x + 1];
+		int current_range  = fp1_pos - f0_pos;
+		float current_mean  = d_segmented_MSD[blockIdx.y*nSegments + blockIdx.x]*1.44269504088896;
+		float norm = 1.0/sqrt(current_mean);
+		size_t global_pos = blockIdx.y*nSamples + threadIdx.x;
+		if(threadIdx.x<(current_range>>1)){
+			d_input[global_pos].x *= norm;
+			d_input[global_pos].y *= norm;
+		}
+		if(threadIdx.x==0){
+			d_input[global_pos].x = 1.0;
+			d_input[global_pos].y = 0.0;
+		}
+	}
+	else {
+		// This is presto deredning scheme
+		int fm1_pos = d_segment_sizes[blockIdx.x - 1];
+		int f0_pos  = d_segment_sizes[blockIdx.x + 0];
+		int fp1_pos = d_segment_sizes[blockIdx.x + 1];
+		int previous_range = f0_pos - fm1_pos;
+		int current_range  = fp1_pos - f0_pos;
+		float previous_mean = d_segmented_MSD[blockIdx.y*nSegments + blockIdx.x - 1]*1.44269504088896;
+		float current_mean  = d_segmented_MSD[blockIdx.y*nSegments + blockIdx.x]*1.44269504088896;
+		
+		int range = ((previous_range + current_range)>>1);
+		int i = range - threadIdx.x;
+		float slope = (current_mean - previous_mean) / ((float) range);
+		float norm  = 1.0/sqrt(previous_mean + slope*i);
+		int local_pos = fm1_pos + (previous_range>>1) + i;
+		
+		if( i >= 0 && i<=range && local_pos < nSamples){
+			size_t global_pos = blockIdx.y*nSamples + local_pos;
+			d_input[global_pos].x *= norm;
+			d_input[global_pos].y *= norm;
+		}
+		
+		if(blockIdx.x == (gridDim.x - 2)){
+			int local_pos = fm1_pos + (previous_range>>1) + range + threadIdx.x;
+			if(local_pos < nSamples){
+				size_t global_pos = blockIdx.y*nSamples + local_pos;
+				d_input[global_pos].x *= norm;
+				d_input[global_pos].y *= norm;
+			}
+		}
+	}
+}
+
+
 //---------------------------- WRAPPERS --------------------------
 
 void call_kernel_spectrum_whitening_SGP1(
@@ -210,5 +440,51 @@ void call_kernel_spectrum_whitening_SGP1(
 	GPU_kernel_spectrum_whitening_SGP1<<< grid_size, block_size, smem_bytes, stream >>>(d_input, nSamples);
 }
 
+void call_kernel_segmented_MSD(
+	const  dim3 &block_size, 
+	const  dim3 &grid_size, 
+	const  int &smem_bytes, 
+	const  cudaStream_t &stream, 
+	float  *d_segmented_MSD, 
+	float2 *d_input, 
+	int    *d_segment_sizes,
+	size_t nSamples,
+	int    nSegments
+) {	
+	GPU_kernel_segmented_MSD<<< grid_size, block_size, smem_bytes, stream >>>(d_segmented_MSD, d_input, d_segment_sizes, nSamples, nSegments);
+}
+
+void call_kernel_segmented_median(
+	const  dim3 &block_size, 
+	const  dim3 &grid_size, 
+	const  int &smem_bytes, 
+	const  cudaStream_t &stream, 
+	float  *d_segmented_MSD, 
+	float2 *d_input, 
+	int    *d_segment_sizes,
+	size_t nSamples,
+	int    nSegments
+) {	
+	GPU_kernel_segmented_median<Sort_256><<< grid_size, block_size, smem_bytes, stream >>>(d_segmented_MSD, d_input, d_segment_sizes, nSamples, nSegments);
+}
+
+void call_kernel_spectrum_whitening_SGP2(
+	const  dim3 &block_size, 
+	const  dim3 &grid_size, 
+	const  int &smem_bytes, 
+	const  cudaStream_t &stream, 
+	float  *d_segmented_MSD, 
+	float2 *d_input,
+	int    *d_segment_sizes,
+	size_t nSamples,
+	int    nSegments
+) {	
+	GPU_kernel_spectrum_whitening_SGP2<<< grid_size, block_size, smem_bytes, stream >>>(d_segmented_MSD, d_input, d_segment_sizes, nSamples, nSegments);
+}
+
 } //namespace astroaccelerate
+
+
+
+
 

--- a/src/aa_host_utilities.cpp
+++ b/src/aa_host_utilities.cpp
@@ -1,0 +1,239 @@
+#include <stdio.h>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <algorithm>
+#include "aa_host_utilities.hpp"
+
+namespace astroaccelerate {
+
+//---------------------------------------------------------------------------------
+//-------> Kahan MSD
+void d_kahan_summation(float *signal, size_t nDMs, size_t nTimesamples, size_t offset, float *result, float *error){
+	double sum;
+	double sum_error;
+	double a,b;
+	
+	sum=0;
+	sum_error=0;
+	for(size_t d=0;d<nDMs; d++){
+		for(size_t s=0; s<(nTimesamples-offset); s++){
+			a=signal[(size_t) (d*nTimesamples + s)]-sum_error;
+			b=sum+a;
+			sum_error=(b-sum);
+			sum_error=sum_error-a;
+			sum=b;
+		}
+	}
+	*result=sum;
+	*error=sum_error;
+}
+
+void d_kahan_sd(float *signal, size_t nDMs, size_t nTimesamples, size_t offset, double mean, float *result, float *error){
+	double sum;
+	double sum_error;
+	double a,b,dtemp;
+	
+	sum=0;
+	sum_error=0;
+	for(size_t d=0;d<nDMs; d++){
+		for(size_t s=0; s<(nTimesamples-offset); s++){
+			dtemp=(signal[(size_t) (d*nTimesamples + s)]-sum_error - mean);
+			a=dtemp*dtemp;
+			b=sum+a;
+			sum_error=(b-sum);
+			sum_error=sum_error-a;
+			sum=b;
+		}
+	}
+	*result=sum;
+	*error=sum_error;
+}
+
+void MSD_Kahan(float *h_input, size_t nDMs, size_t nTimesamples, size_t offset, double *mean, double *sd){
+	float error, signal_mean, signal_sd;
+	size_t nElements=nDMs*(nTimesamples-offset);
+	
+	d_kahan_summation(h_input, nDMs, nTimesamples, offset, &signal_mean, &error);
+	signal_mean=signal_mean/nElements;
+	
+	d_kahan_sd(h_input, nDMs, nTimesamples, offset, signal_mean, &signal_sd, &error);
+	signal_sd=sqrt(signal_sd/nElements);
+
+	*mean=signal_mean;
+	*sd=signal_sd;
+}
+//-------> Kahan MSD
+//---------------------------------------------------------------------------------
+
+float Calculate_median(float *data, size_t primary_size){
+	float median;
+	std::sort(data, data + primary_size);
+	int middle = (primary_size>>1);
+	if(primary_size%2==0){
+		median = (data[middle] + data[middle + 1])/2;
+		//median = data[middle + 1];
+	}
+	else {
+		median = data[middle];
+	}
+	return(median);
+}
+
+
+void Export_data_to_file(float2 *data, size_t primary_size, size_t secondary_size, const char *filename){
+    std::ofstream FILEOUT;
+    FILEOUT.open (filename, std::ofstream::out);
+	for(size_t sec=0; sec<secondary_size; sec++){
+		for(size_t prim=0; prim<primary_size; prim++){
+			size_t pos = sec*primary_size + prim;
+			double power = sqrt(data[pos].x*data[pos].x + data[pos].y*data[pos].y);
+			FILEOUT << data[pos].x << " " << data[pos].y << " " << power << std::endl;
+		}
+		FILEOUT << std::endl;
+		FILEOUT << std::endl;
+	}
+    FILEOUT.close();
+}
+
+void Export_data_to_file(float *data, size_t primary_size, size_t secondary_size, const char *filename){
+    std::ofstream FILEOUT;
+    FILEOUT.open (filename, std::ofstream::out);
+	for(size_t sec=0; sec<secondary_size; sec++){
+		for(size_t prim=0; prim<primary_size; prim++){
+			size_t pos = sec*primary_size + prim;
+			FILEOUT << data[pos] << std::endl;
+		}
+		FILEOUT << std::endl;
+		FILEOUT << std::endl;
+	}
+    FILEOUT.close();
+}
+
+void Export_data_to_file(float2 *data1, float2 *data2, float2 *data3, size_t primary_size, const char *filename){
+    std::ofstream FILEOUT;
+    FILEOUT.open (filename, std::ofstream::out);
+	for(size_t prim=0; prim<primary_size; prim++){
+		size_t pos = prim;
+		double power1 = sqrt(data1[pos].x*data1[pos].x + data1[pos].y*data1[pos].y);
+		double power2 = sqrt(data2[pos].x*data2[pos].x + data2[pos].y*data2[pos].y);
+		double power3 = sqrt(data3[pos].x*data3[pos].x + data3[pos].y*data3[pos].y);
+		FILEOUT << power1 << " " << power2 << " " << power3 << std::endl;
+	}
+	FILEOUT << std::endl;
+	FILEOUT << std::endl;
+    FILEOUT.close();
+}
+
+void dered_with_MSD(float2 *data, int nSamples, int *segment_sizes, int nSegments, float *MSD){
+	for(int s=0; s<nSegments; s++){
+		if(s==0){
+			// First segment cannot calculate slope thus it is normalized by mean only
+			int f0_pos  = segment_sizes[s + 0];
+			int fp1_pos = segment_sizes[s + 1];
+			int current_range  = fp1_pos - f0_pos;
+			float current_mean = MSD[2*s];
+			float norm = 1.0/sqrt(current_mean);
+			
+			data[0].x = 1.0;
+			data[0].y = 0.0;
+			for(int i=1; i<(current_range>>1); i++){
+				data[i].x *= norm;
+				data[i].y *= norm;
+			}
+		}
+		else {
+			// This is presto deredning scheme
+			int fm1_pos = segment_sizes[s - 1];
+			int f0_pos  = segment_sizes[s + 0];
+			int fp1_pos = segment_sizes[s + 1];
+			int previous_range = f0_pos - fm1_pos;
+			int current_range  = fp1_pos - f0_pos;
+			float previous_mean = MSD[2*(s - 1)];
+			float current_mean  = MSD[2*(s)];
+			int range = ((previous_range + current_range)>>1);
+			float slope = (current_mean - previous_mean) / ((float) range);
+			
+			for(int i=0; i<=range; i++){
+				int local_pos = fm1_pos + (previous_range>>1) + i;
+				float norm = 1.0/sqrt(previous_mean + slope*(range-i));
+				if(local_pos < nSamples){
+					data[local_pos].x *= norm;
+					data[local_pos].y *= norm;
+				}
+			}
+			
+			// deal with the end
+			if( s==(nSegments-2) ){
+				int range_to_end = nSamples - (fm1_pos + (previous_range>>1) + range);
+				for(int i=0; i<range_to_end; i++){
+					int local_pos = fm1_pos + (previous_range>>1) + range + i;
+					float norm = 1.0/sqrt(previous_mean + slope*i);
+					if(local_pos < nSamples){
+						data[local_pos].x *= norm;
+						data[local_pos].y *= norm;
+					}
+				}
+			}
+		}
+	}
+}
+
+void dered_with_MED(float2 *data, int nSamples, int *segment_sizes, int nSegments, float *MED){
+	for(int s=0; s<nSegments; s++){
+		if(s==0){
+			// First segment cannot calculate slope thus it is normalized by mean only
+			int f0_pos  = segment_sizes[s + 0];
+			int fp1_pos = segment_sizes[s + 1];
+			int current_range  = fp1_pos - f0_pos;
+			float current_mean = MED[s] / log(2.0);
+			float norm = 1.0/sqrt(current_mean);
+			
+			data[0].x = 1.0;
+			data[0].y = 0.0;
+			for(int i=1; i<(current_range>>1); i++){
+				data[i].x *= norm;
+				data[i].y *= norm;
+			}
+		}
+		else {
+			// This is presto deredning scheme
+			int fm1_pos = segment_sizes[s - 1];
+			int f0_pos  = segment_sizes[s + 0];
+			int fp1_pos = segment_sizes[s + 1];
+			int previous_range = f0_pos - fm1_pos;
+			int current_range  = fp1_pos - f0_pos;
+			float previous_mean = MED[s - 1] / log(2.0);
+			float current_mean  = MED[s] / log(2.0);
+			int range   = ((previous_range + current_range)>>1);
+			float slope = (current_mean - previous_mean) / ((float) range);
+			//printf("previous_mean=%e; current_mean=%e; slope=%e;\n", previous_mean, current_mean, slope);
+			for(int i=0; i<=range; i++){
+				int local_pos = fm1_pos + (previous_range>>1) + i;
+				float norm = 1.0/sqrt(previous_mean + slope*(range-i));
+				if(local_pos < nSamples){
+					data[local_pos].x *= norm;
+					data[local_pos].y *= norm;
+				}
+			}
+			
+			// deal with the end
+			if( s==(nSegments-2) ){
+				int range_to_end = nSamples - (fm1_pos + (previous_range>>1) + range);
+				for(int i=0; i<range_to_end; i++){
+					int local_pos = fm1_pos + (previous_range>>1) + range + i;
+					float norm = 1.0/sqrt(previous_mean + slope*i);
+					if(local_pos < nSamples){
+						data[local_pos].x *= norm;
+						data[local_pos].y *= norm;
+					}
+				}
+			}
+		}
+	}
+}
+
+
+
+} //namespace astroaccelerate

--- a/src/aa_main.cpp
+++ b/src/aa_main.cpp
@@ -215,8 +215,8 @@ int main(int argc, char *argv[]) {
 		LOG(log_level::notice, "The pipeline finished successfully.");
 		if (pipeline.find(aa_pipeline::component::periodicity) != pipeline.end()) {
 			LOG(log_level::notice, "Writing periodicity candidates to disk.");
-			pipeline_manager.Write_to_disk_PSR_candidates("PSR_candidate_list.dat");
-			pipeline_manager.Write_to_disk_PSR_interbin_candidates("PSR_interbin_candidate_list.dat");
+			pipeline_manager.Write_to_disk_PSR_candidates("global_periods.dat");
+			pipeline_manager.Write_to_disk_PSR_interbin_candidates("global_interbin.dat");
 		}
 	}
 	else {

--- a/src/aa_main.cpp
+++ b/src/aa_main.cpp
@@ -213,6 +213,11 @@ int main(int argc, char *argv[]) {
 	// Run the pipeline
 	if (pipeline_manager.run()) {
 		LOG(log_level::notice, "The pipeline finished successfully.");
+		if (pipeline.find(aa_pipeline::component::periodicity) != pipeline.end()) {
+			LOG(log_level::notice, "Writing periodicity candidates to disk.");
+			pipeline_manager.Write_to_disk_PSR_candidates("PSR_candidate_list.dat");
+			pipeline_manager.Write_to_disk_PSR_interbin_candidates("PSR_interbin_candidate_list.dat");
+		}
 	}
 	else {
 		LOG(log_level::error, "The pipeline could not start or had errors.");

--- a/src/aa_main.cpp
+++ b/src/aa_main.cpp
@@ -133,13 +133,22 @@ int main(int argc, char *argv[]) {
 	
 	if (pipeline.find(aa_pipeline::component::periodicity) != pipeline.end()) {
 		//If these settings come from the input_file, then move them into aa_config to be read from the file.
+		int harmonic_sum_algorithm = 1; // Greedy
+		bool enable_scalloping_loss_mitigation = true;
+		bool enable_interbinning = true;
+		bool enable_spectrum_whitening = true;
 		aa_periodicity_plan periodicity_plan(
+			pipeline_manager.ddtr_strategy(),
 			user_flags.periodicity_sigma_cutoff,
+			msd_baseline_noise,
 			user_flags.sigma_constant,
 			user_flags.periodicity_nHarmonics,
-			user_flags.power,
+			harmonic_sum_algorithm,
 			user_flags.candidate_algorithm,
-			msd_baseline_noise);
+			enable_scalloping_loss_mitigation,
+			enable_interbinning,
+			enable_spectrum_whitening
+		);
 		pipeline_manager.bind(periodicity_plan);
 	}
 

--- a/src/aa_main.cpp
+++ b/src/aa_main.cpp
@@ -134,7 +134,7 @@ int main(int argc, char *argv[]) {
 	if (pipeline.find(aa_pipeline::component::periodicity) != pipeline.end()) {
 		//If these settings come from the input_file, then move them into aa_config to be read from the file.
 		int harmonic_sum_algorithm = 1; // Greedy
-		bool enable_scalloping_loss_mitigation = true;
+		bool enable_scalloping_loss_mitigation = false;
 		bool enable_interbinning = true;
 		bool enable_spectrum_whitening = true;
 		aa_periodicity_plan periodicity_plan(

--- a/src/aa_py_pipeline_api.cpp
+++ b/src/aa_py_pipeline_api.cpp
@@ -122,6 +122,20 @@ namespace astroaccelerate {
 	size_t aa_py_spd_nCandidates(aa_pipeline_api<unsigned short> *const obj){
 		return obj->SPD_nCandidates();
 	}
+	
+	// ----------------------- PSR -------------------------
+	size_t aa_py_get_psr_nCandidates(aa_pipeline_api<unsigned short> *const obj){
+		return obj->Get_PSR_candidates();
+	}
+	
+	size_t aa_py_get_psr_interbin_nCandidates(aa_pipeline_api<unsigned short> *const obj){
+		return obj->Get_PSR_interbin_candidates();
+	}
+	
+	void aa_py_write_to_disk_psr_candidates(aa_pipeline_api<unsigned short> *const obj, const char *filename){
+		obj->Write_to_disk_PSR_candidates(filename);
+	}
+	// ----------------------- PSR -------------------------
 
 	int aa_py_current_range(aa_pipeline_api<unsigned short> *const obj){
 		return obj->get_current_range();

--- a/src/aa_py_pipeline_api.cpp
+++ b/src/aa_py_pipeline_api.cpp
@@ -76,9 +76,9 @@ namespace astroaccelerate {
 	return new aa_analysis_strategy(obj->analysis_strategy());
       }
 
-      bool aa_py_pipeline_api_bind_periodicity_plan(aa_pipeline_api<unsigned short> *const obj, const float sigma_cutoff, const float sigma_constant, const int nHarmonics, const int export_powers, const bool candidate_algorithm, const bool enable_msd_baseline_noise) {
-	aa_periodicity_plan plan(sigma_cutoff, sigma_constant, nHarmonics, export_powers, candidate_algorithm, enable_msd_baseline_noise);
-	return obj->bind(plan);
+      bool aa_py_pipeline_api_bind_periodicity_plan(aa_pipeline_api<unsigned short> *const obj, const float sigma_cutoff, const bool enable_outlier_rejection, const float sigma_outlier_rejection_threshold, const int nHarmonics, const int candidate_selection_algorithm) {
+          aa_periodicity_plan plan(obj->ddtr_strategy(), sigma_cutoff, enable_outlier_rejection, sigma_outlier_rejection_threshold, nHarmonics, candidate_selection_algorithm);
+          return obj->bind(plan);
       }
 
       bool aa_py_pipeline_api_bind_fdas_plan(aa_pipeline_api<unsigned short> *const obj, const float sigma_cutoff, const float sigma_constant, const bool enable_msd_baseline_noise) {

--- a/src/aa_py_pipeline_api.cpp
+++ b/src/aa_py_pipeline_api.cpp
@@ -124,11 +124,11 @@ namespace astroaccelerate {
 	}
 	
 	// ----------------------- PSR -------------------------
-	size_t aa_py_get_psr_nCandidates(aa_pipeline_api<unsigned short> *const obj){
+	float* aa_py_get_psr_nCandidates(aa_pipeline_api<unsigned short> *const obj){
 		return obj->Get_PSR_candidates();
 	}
 	
-	size_t aa_py_get_psr_interbin_nCandidates(aa_pipeline_api<unsigned short> *const obj){
+	float* aa_py_get_psr_interbin_nCandidates(aa_pipeline_api<unsigned short> *const obj){
 		return obj->Get_PSR_interbin_candidates();
 	}
 	

--- a/src/presto_funcs.cpp
+++ b/src/presto_funcs.cpp
@@ -466,13 +466,14 @@ void presto_place_complex_kernel(cufftComplex * kernel, int numkernel, cufftComp
     newbuflen = initialbuflen * log(newoffset);
     if (newbuflen > maxbuflen)
       newbuflen = maxbuflen;
-
+	
     while (newoffset + newbuflen < numamps) {
-      /* Calculate the next mean */
+      //printf("newoffset=%d; lastbuflen=%d; newbuflen=%d;\n", newoffset, lastbuflen, newbuflen);
+	  /* Calculate the next mean */
       mean_new = median(powers + newoffset, newbuflen) / log(2.0);
       //slope = (mean_new-mean_old)/(0.5*(newbuflen+lastbuflen));
       slope = (mean_new - mean_old) / (newbuflen + lastbuflen);
-
+		//printf("mean_old=%e; mean_new=%e; slope=%e\n", mean_old, mean_new, slope);
       /* Correct the previous segment */
       lineoffset = 0.5 * (newbuflen + lastbuflen);
       for (ii = 0; ii < lastbuflen; ii++) {


### PR DESCRIPTION
---
Update of the periodicity search

This update adds several upgrades for periodicity search. It adds three 1D harmonic sum algorithms, two are based on PRESTO, the third is the new greedy harmonic sum. This upgrade also adds Spectrum whitening and median normalization.
Candidates are now sent to the host and it is up to the user to handle them further.
---

**Interfaces**
Will this pull request result in a backwards-incompatible interface change: No

Expected semantic version number increment category (Please indicate x.y.z): y+3
