### PR TITLE
frequency correction based on greedy hrms

### DIFF
--- a/include/aa_device_peak_find.hpp
+++ b/include/aa_device_peak_find.hpp
@@ -16,7 +16,21 @@ namespace astroaccelerate {
 
   extern void PEAK_FIND_FOR_FDAS(float *d_ffdot_plane, float *d_peak_list, float *d_MSD, int nDMs, int nTimesamples, float threshold, unsigned int max_peak_size, unsigned int *gmem_peak_pos, float DM_trial);
 
-  extern int Peak_find_for_periodicity_search(float *d_input_SNR, ushort *d_input_harmonics, float *d_peak_list, int nDMs, int nTimesamples, float threshold, int max_peak_size, int *gmem_peak_pos, float* d_MSD, int DM_shift, int inBin, bool transposed_data);
+	extern int Peak_find_for_periodicity_search(
+		float *d_input_SNR, 
+		ushort *d_input_harmonics, 
+		float *d_peak_list, 
+		int nDMs, 
+		int nTimesamples, 
+		float threshold, 
+		int max_peak_size, 
+		int *gmem_peak_pos, 
+		float* d_MSD, 
+		int DM_shift, 
+		int inBin, 
+		bool transposed_data, 
+		int enable_greedy_postprocessing
+	);
 
   extern void SPDT_peak_find_stencil_7x7(float *d_output_SNR, ushort *d_output_taps, unsigned int *d_peak_list_DM, unsigned int *d_peak_list_TS, float *d_peak_list_SNR, unsigned int *d_peak_list_BW, int nDMs, int nTimesamples, float threshold, int max_peak_size, int *gmem_peak_pos, int shift, std::vector<PulseDetection_plan> *PD_plan, int max_iteration);
 

--- a/include/aa_device_peak_find_kernel.hpp
+++ b/include/aa_device_peak_find_kernel.hpp
@@ -33,7 +33,8 @@ namespace astroaccelerate {
       int *const gmem_pos,
       float const *const d_MSD,
       const int &DM_shift,
-      const int &DIT_value
+      const int &DIT_value,
+      const int &enable_greedy_postprocessing
   );
 
   /** \brief Kernel wrapper function for peak_find_for_periods kernel function. */

--- a/include/aa_device_threshold.hpp
+++ b/include/aa_device_threshold.hpp
@@ -11,7 +11,7 @@ namespace astroaccelerate {
 
   extern int Threshold_for_periodicity_transposed(float *d_input, ushort *d_input_harms, float *d_output_list,  int *gmem_pos, float *d_MSD, float threshold, int primary_size, int secondary_size, int DM_shift, int inBin, int max_list_size);
 
-  extern int Threshold_for_periodicity_normal(float *d_input_SNR, ushort *d_input_harms, float *d_output_list,  int *gmem_pos, float *d_MSD, float threshold, int nTimesamples, int nDMs, int DM_shift, int inBin, int max_list_size);
+  extern int Threshold_for_periodicity_normal(float *d_input_SNR, ushort *d_input_harms, float *d_output_list,  int *gmem_pos, float *d_MSD, float threshold, int nTimesamples, int nDMs, int DM_shift, int inBin, int max_list_size, int enable_greedy_postprocessing);
 
 } // namespace astroaccelerate
   

--- a/include/aa_device_threshold_kernel.hpp
+++ b/include/aa_device_threshold_kernel.hpp
@@ -40,7 +40,8 @@ namespace astroaccelerate {
       const int &nDMs,
       const int &DM_shift,
       const int &max_list_size,
-      const int &DIT_value
+      const int &DIT_value,
+      const int &enable_greedy_postprocessing
   );
 
   /** Kernel wrapper function for GPU_Threshold_for_periodicity_kernel kernel function. */

--- a/src/aa_device_peak_find.cu
+++ b/src/aa_device_peak_find.cu
@@ -50,7 +50,7 @@ namespace astroaccelerate {
     call_kernel_dilate_peak_find_for_fdas(gridSize, blockDim, d_ffdot_plane, d_peak_list, d_MSD, nTimesamples, nDMs, 0, threshold, max_peak_size, gmem_peak_pos, DM_trial);
   }
 
-  int Peak_find_for_periodicity_search(float *d_input_SNR, ushort *d_input_harmonics, float *d_peak_list, int nTimesamples, int nDMs, float threshold, int max_peak_size, int *gmem_peak_pos, float *d_MSD, int DM_shift, int inBin, bool transposed_data){
+  int Peak_find_for_periodicity_search(float *d_input_SNR, ushort *d_input_harmonics, float *d_peak_list, int nTimesamples, int nDMs, float threshold, int max_peak_size, int *gmem_peak_pos, float *d_MSD, int DM_shift, int inBin, bool transposed_data, int enable_greedy_postprocessing){
       // nTimesamples = secondary_size
       // nDMs = primary_size
       //---------> Nvidia stuff
@@ -124,7 +124,7 @@ namespace astroaccelerate {
         }
         else {
             dim3 gridSize(nBlocks_p, nBlocks_s, 1);
-            call_kernel_peak_find_for_periodicity_normal(gridSize, blockDim, &d_input_SNR[shift*primary_size], d_input_harmonics, d_peak_list, primary_size, secondary_size, 0, threshold, max_peak_size, gmem_peak_pos, d_MSD, DM_shift, inBin);
+            call_kernel_peak_find_for_periodicity_normal(gridSize, blockDim, &d_input_SNR[shift*primary_size], d_input_harmonics, d_peak_list, primary_size, secondary_size, 0, threshold, max_peak_size, gmem_peak_pos, d_MSD, DM_shift, inBin, enable_greedy_postprocessing);
         }
         shift = shift + secondary_size_per_chunk[f];
       }

--- a/src/aa_device_threshold.cu
+++ b/src/aa_device_threshold.cu
@@ -119,7 +119,7 @@ int Threshold_for_periodicity_transposed(float *d_input, ushort *d_input_harms, 
   
   
   
-int Threshold_for_periodicity_normal(float *d_input_SNR, ushort *d_input_harms, float *d_output_list,  int *gmem_pos, float *d_MSD, float threshold, int nTimesamples, int nDMs, int DM_shift, int inBin, int max_list_size) {
+int Threshold_for_periodicity_normal(float *d_input_SNR, ushort *d_input_harms, float *d_output_list,  int *gmem_pos, float *d_MSD, float threshold, int nTimesamples, int nDMs, int DM_shift, int inBin, int max_list_size, int enable_greedy_postprocessing) {
     //---------> Nvidia stuff
     cudaDeviceProp deviceProp;
     cudaGetDeviceProperties(&deviceProp, CARD);
@@ -143,8 +143,8 @@ int Threshold_for_periodicity_normal(float *d_input_SNR, ushort *d_input_harms, 
 	
     if(nBlocks_x > max_x) return(1);
     if(nBlocks_y > max_y) return(2);
-
-    call_kernel_GPU_Threshold_for_periodicity_normal_kernel(gridSize, blockSize, d_input_SNR, d_input_harms, d_output_list, gmem_pos, d_MSD, threshold, nTimesamples, nDMs, DM_shift, max_list_size, inBin);
+	printf("In thresholding\n");
+    call_kernel_GPU_Threshold_for_periodicity_normal_kernel(gridSize, blockSize, d_input_SNR, d_input_harms, d_output_list, gmem_pos, d_MSD, threshold, nTimesamples, nDMs, DM_shift, max_list_size, inBin, enable_greedy_postprocessing);
 
     return (0);
   }


### PR DESCRIPTION
Introduced correction for fundamental frequency detected by greedy harmonic sum. This correction takes into account shift of the higher harmonics and corrects the fundamental frequency of the pulsar to better match the true frequency.